### PR TITLE
Better use of js conventions w/ thread id

### DIFF
--- a/packages/core/src/multiaddr/convert.ts
+++ b/packages/core/src/multiaddr/convert.ts
@@ -1,12 +1,12 @@
 import varint from 'varint'
-import { ThreadID } from '../thread/id'
+import { ThreadID } from '../thread'
 import { protocols } from './protocols'
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const Convert = require('multiaddr/src/convert')
 
 function thread2buf(str: string) {
   // const buf = Buffer.from(str)
-  const buf = ThreadID.fromEncoded(str).bytes()
+  const buf = ThreadID.fromString(str).toBytes()
   const size = Buffer.from(varint.encode(buf.length))
   return Buffer.concat([size, buf])
 }
@@ -19,7 +19,7 @@ function buf2thread(buf: Buffer) {
     throw new Error('inconsistent lengths')
   }
 
-  return ThreadID.fromBytes(buf).string()
+  return ThreadID.fromBytes(buf).toString()
 }
 
 export function toString(prt: string | number, buf: Buffer) {

--- a/packages/core/src/thread/id.spec.ts
+++ b/packages/core/src/thread/id.spec.ts
@@ -1,40 +1,40 @@
 import { expect } from 'chai'
-import { ThreadID, Variant, V1 } from './id'
+import { ThreadID } from './id'
 
 describe('Thread ID', () => {
   it('should be able to create a random ID', () => {
-    const i = ThreadID.fromRandom(Variant.Raw, 16)
+    const i = ThreadID.fromRandom(ThreadID.Variant.Raw, 16)
     expect(i).to.not.be.undefined
-    expect(i.bytes()).to.have.length(18)
-    expect(i.defined()).to.be.true
+    expect(i.toBytes()).to.have.length(18)
+    expect(i.isDefined()).to.be.true
   })
   it('should decode an ID from a base-32 encoded string', () => {
-    const i = ThreadID.fromRandom(Variant.Raw, 32)
-    const j = ThreadID.fromEncoded(i.string())
-    expect(i.string()).to.equal(j.string())
+    const i = ThreadID.fromRandom(ThreadID.Variant.Raw, 32)
+    const j = ThreadID.fromString(i.toString())
+    expect(i.toString()).to.equal(j.toString())
   })
   it('should be able to extract the encoding', () => {
-    const i = ThreadID.fromRandom(Variant.Raw, 16)
-    const e = ThreadID.isEncoded(i.string())
+    const i = ThreadID.fromRandom(ThreadID.Variant.Raw, 16)
+    const e = ThreadID.getEncoding(i.toString())
     expect(e).to.equal('base32')
   })
   it('should have a valid version number', () => {
-    const i = ThreadID.fromRandom(Variant.Raw, 16)
+    const i = ThreadID.fromRandom(ThreadID.Variant.Raw, 16)
     const v = i.version()
-    expect(v).to.equal(V1)
+    expect(v).to.equal(ThreadID.V1)
   })
   it('should have a valid variant number', () => {
-    let i = ThreadID.fromRandom(Variant.Raw, 16)
+    let i = ThreadID.fromRandom(ThreadID.Variant.Raw, 16)
     let v = i.variant()
-    expect(v).to.equal(Variant.Raw)
+    expect(v).to.equal(ThreadID.Variant.Raw)
 
-    i = ThreadID.fromRandom(Variant.AccessControlled, 32)
+    i = ThreadID.fromRandom(ThreadID.Variant.AccessControlled, 32)
     v = i.variant()
-    expect(v).to.equal(Variant.AccessControlled)
+    expect(v).to.equal(ThreadID.Variant.AccessControlled)
   })
   it('should be able to round-trip to and from bytes', () => {
-    const i = ThreadID.fromRandom(Variant.Raw, 16)
-    const b = i.bytes()
+    const i = ThreadID.fromRandom(ThreadID.Variant.Raw, 16)
+    const b = i.toBytes()
     const n = ThreadID.fromBytes(b)
     expect(n).to.deep.equal(i)
     expect(i.equals(n)).to.be.true

--- a/packages/database/src/db.spec.ts
+++ b/packages/database/src/db.spec.ts
@@ -3,7 +3,7 @@
 ;(global as any).WebSocket = require('isomorphic-ws')
 
 import { expect } from 'chai'
-import { Multiaddr, ThreadID, Variant } from '@textile/threads-core'
+import { Multiaddr, ThreadID } from '@textile/threads-core'
 import LevelDatastore from 'datastore-level'
 import delay from 'delay'
 import { isBrowser } from 'browser-or-node'
@@ -130,7 +130,7 @@ describe('Database', () => {
       // Boilerplate to generate peer1 thread-addr
       const hostID = await d1.network.getHostID()
       const hostAddr = new Multiaddr('/dns4/threads1/tcp/4006')
-      const addr = threadAddr(hostAddr, hostID.toB58String(), id1.string())
+      const addr = threadAddr(hostAddr, hostID.toB58String(), id1.toString())
 
       // Peer 2: Create a completely parallel db2, which will sync with the previous one and should
       // have the same state of dummy.
@@ -179,7 +179,7 @@ describe('Database', () => {
       const eventBus = new EventBus(new DomainDatastore(datastore, new Key('eventbus')), network)
       const db = new Database(datastore, { dispatcher, network, eventBus })
 
-      const id = ThreadID.fromRandom(Variant.Raw, 32)
+      const id = ThreadID.fromRandom(ThreadID.Variant.Raw, 32)
       await db.open(id)
 
       await db.newCollectionFromObject<DummyInstance>('dummy', {

--- a/packages/database/src/db.ts
+++ b/packages/database/src/db.ts
@@ -109,7 +109,7 @@ export class Database {
    * @param schema A valid JSON schema object.
    */
   async newCollection<T extends Instance>(name: string, schema: JSONSchema) {
-    if (!this.threadID?.defined()) {
+    if (!this.threadID?.isDefined()) {
       await this.open()
     }
     if (this.collections.has(name)) {
@@ -147,7 +147,7 @@ export class Database {
         this.threadID = ThreadID.fromBytes(await this.child.get(idKey))
       } else {
         const info = await createThread(this.network)
-        await this.child.put(idKey, info.id.bytes())
+        await this.child.put(idKey, info.id.toBytes())
         this.threadID = info.id
       }
     } else {
@@ -164,7 +164,7 @@ export class Database {
         } catch (_err) {
           info = await createThread(this.network, threadID)
         }
-        await this.child.put(idKey, info.id.bytes())
+        await this.child.put(idKey, info.id.toBytes())
         this.threadID = info.id
       }
     }
@@ -183,7 +183,7 @@ export class Database {
       // This is the only address we know about... and the port is wrong
       const hostAddr = Multiaddr.fromNodeAddress(parse(this.network.client.config.host), 'tcp')
       const pa = new Multiaddr(`/p2p/${hostID.toB58String()}`)
-      const ta = new Multiaddr(`/thread/${info.id.string()}`)
+      const ta = new Multiaddr(`/thread/${info.id.toString()}`)
       const full = hostAddr.encapsulate(pa.encapsulate(ta))
       return {
         dbKey: info.key,
@@ -225,7 +225,7 @@ export class Database {
   }
 
   private async onEvents(...events: Event[]) {
-    const id = this.threadID?.bytes()
+    const id = this.threadID?.toBytes()
     if (id !== undefined) {
       for (const body of events) {
         await this.eventBus.push({ id, body })

--- a/packages/database/src/utils.ts
+++ b/packages/database/src/utils.ts
@@ -1,6 +1,5 @@
 import {
   ThreadInfo,
-  Variant,
   EventHeader,
   ThreadID,
   Multiaddr,
@@ -26,7 +25,7 @@ export function decodeRecord<T = any>(rec: ThreadRecord, info: ThreadInfo) {
 
 export async function createThread(
   network: Network,
-  id: ThreadID = ThreadID.fromRandom(Variant.Raw, 32),
+  id: ThreadID = ThreadID.fromRandom(ThreadID.Variant.Raw, 32),
 ) {
   const threadKey = Key.fromRandom(true)
   // @todo: Let users/developers provide their own keys here.

--- a/packages/network-client/src/index.spec.ts
+++ b/packages/network-client/src/index.spec.ts
@@ -6,7 +6,7 @@ import { randomBytes } from 'libp2p-crypto'
 import { expect } from 'chai'
 import PeerId from 'peer-id'
 import { keys } from 'libp2p-crypto'
-import { ThreadID, Variant, ThreadInfo, Block, ThreadRecord, Multiaddr, Key } from '@textile/threads-core'
+import { ThreadID, ThreadInfo, Block, ThreadRecord, Multiaddr, Key } from '@textile/threads-core'
 import { createEvent, createRecord } from '@textile/threads-encoding'
 import { Client } from '.'
 
@@ -15,14 +15,14 @@ const proxyAddr2 = 'http://127.0.0.1:6207'
 const ed25519 = keys.supportedKeys.ed25519
 
 async function createThread(client: Client) {
-  const id = ThreadID.fromRandom(Variant.Raw, 32)
+  const id = ThreadID.fromRandom(ThreadID.Variant.Raw, 32)
   const threadKey = Key.fromRandom()
   return client.createThread(id, { threadKey })
 }
 
 function threadAddr(hostAddr: Multiaddr, hostID: PeerId, info: ThreadInfo) {
   const pa = new Multiaddr(`/p2p/${hostID.toB58String()}`)
-  const ta = new Multiaddr(`/thread/${info.id.string()}`)
+  const ta = new Multiaddr(`/thread/${info.id.toString()}`)
   return hostAddr.encapsulate(pa.encapsulate(ta))
 }
 
@@ -39,10 +39,10 @@ describe('Network Client...', () => {
     })
 
     it('should create a remote thread', async () => {
-      const id = ThreadID.fromRandom(Variant.Raw, 32)
+      const id = ThreadID.fromRandom(ThreadID.Variant.Raw, 32)
       const threadKey = Key.fromRandom()
       const info = await client.createThread(id, { threadKey })
-      expect(info.id.string()).to.equal(id.string())
+      expect(info.id.toString()).to.equal(id.toString())
       expect(info.key).to.not.be.undefined
     }).timeout(5000)
 
@@ -54,7 +54,7 @@ describe('Network Client...', () => {
       const client2 = new Client({ host: proxyAddr2 })
       try {
         const info2 = await client2.addThread(addr, { threadKey: info1.key })
-        expect(info2.id.string()).to.equal(info1.id.string())
+        expect(info2.id.toString()).to.equal(info1.id.toString())
       } catch (err) {
         throw new Error(`unexpected error: ${err}`)
       }
@@ -63,7 +63,7 @@ describe('Network Client...', () => {
     it('should add and then get a remote thread', async () => {
       const info1 = await createThread(client)
       const info2 = await client.getThread(info1.id)
-      expect(info2.id.string()).to.equal(info1.id.string())
+      expect(info2.id.toString()).to.equal(info1.id.toString())
     })
 
     it('should pull a thread for records', async () => {
@@ -101,7 +101,7 @@ describe('Network Client...', () => {
       const info = await createThread(client)
       const body = { foo: 'bar', baz: Buffer.from('howdy') }
       const rec = await client.createRecord(info.id, body)
-      expect(rec?.threadID.string()).to.equal(info.id.string())
+      expect(rec?.threadID.toString()).to.equal(info.id.toString())
       expect(rec?.logID).to.not.be.undefined
       if (rec?.record) {
         const block = rec.record.block
@@ -113,7 +113,7 @@ describe('Network Client...', () => {
 
     it('should be able to add a pre-formed record', async () => {
       // Create a thread, keeping read key and log private key on the client
-      const id = ThreadID.fromRandom(Variant.Raw, 32)
+      const id = ThreadID.fromRandom(ThreadID.Variant.Raw, 32)
       const threadKey = Key.fromRandom(false)
       const privKey = await ed25519.generateKeyPair()
       const logKey = privKey.public

--- a/packages/network-client/src/index.ts
+++ b/packages/network-client/src/index.ts
@@ -119,7 +119,7 @@ export class Client implements Network {
     logger.debug('making create thread request')
     const keys = getThreadKeys(opts)
     const req = new pb.CreateThreadRequest()
-    req.setThreadid(id.bytes())
+    req.setThreadid(id.toBytes())
     req.setKeys(keys)
     const res = (await this.unary(API.CreateThread, req)) as pb.ThreadInfoReply.AsObject
     return threadInfoFromProto(res)
@@ -147,7 +147,7 @@ export class Client implements Network {
   async getThread(id: ThreadID) {
     logger.debug('making get thread request')
     const req = new pb.GetThreadRequest()
-    req.setThreadid(id.bytes())
+    req.setThreadid(id.toBytes())
     const res = (await this.unary(API.GetThread, req)) as pb.ThreadInfoReply.AsObject
     return threadInfoFromProto(res)
   }
@@ -159,7 +159,7 @@ export class Client implements Network {
   async pullThread(id: ThreadID) {
     logger.debug('making pull thread request')
     const req = new pb.PullThreadRequest()
-    req.setThreadid(id.bytes())
+    req.setThreadid(id.toBytes())
     await this.unary(API.PullThread, req)
     return
   }
@@ -171,7 +171,7 @@ export class Client implements Network {
   async deleteThread(id: ThreadID) {
     logger.debug('making delete thread request')
     const req = new pb.DeleteThreadRequest()
-    req.setThreadid(id.bytes())
+    req.setThreadid(id.toBytes())
     await this.unary(API.DeleteThread, req)
     return
   }
@@ -184,7 +184,7 @@ export class Client implements Network {
   async addReplicator(id: ThreadID, addr: Multiaddr) {
     logger.debug('making add replicator request')
     const req = new pb.AddReplicatorRequest()
-    req.setThreadid(id.bytes())
+    req.setThreadid(id.toBytes())
     req.setAddr(addr.buffer)
     const res = (await this.unary(API.AddReplicator, req)) as pb.AddReplicatorReply.AsObject
     const rawId = Buffer.from(res.peerid as string, 'base64')
@@ -201,7 +201,7 @@ export class Client implements Network {
     const info = await this.getThread(id)
     const block = Block.encoder(body, 'dag-cbor').encode()
     const req = new pb.CreateRecordRequest()
-    req.setThreadid(id.bytes())
+    req.setThreadid(id.toBytes())
     req.setBody(block)
     const res = (await this.unary(API.CreateRecord, req)) as pb.NewRecordReply.AsObject
     return info.key && threadRecordFromProto(res, info.key)
@@ -217,7 +217,7 @@ export class Client implements Network {
     logger.debug('making add record request')
     const prec = recordToProto(rec)
     const req = new pb.AddRecordRequest()
-    req.setThreadid(id.bytes())
+    req.setThreadid(id.toBytes())
     req.setLogid(logID.toBytes())
     const record = new pb.Record()
     record.setBodynode(prec.bodynode)
@@ -239,7 +239,7 @@ export class Client implements Network {
     const info = await this.getThread(id)
     if (info.key === undefined) throw new Error('Missing thread keys')
     const req = new pb.GetRecordRequest()
-    req.setThreadid(id.bytes())
+    req.setThreadid(id.toBytes())
     req.setRecordid(rec.buffer)
     const record = (await this.unary(API.GetRecord, req)) as pb.GetRecordReply.AsObject
     if (!record.record) throw new Error('Missing return value')
@@ -253,7 +253,7 @@ export class Client implements Network {
    */
   subscribe(cb: (rec?: ThreadRecord, err?: Error) => void, ...threads: ThreadID[]) {
     logger.debug('making subscribe request')
-    const ids = threads.map(thread => thread.bytes())
+    const ids = threads.map(thread => thread.toBytes())
     const request = new pb.SubscribeRequest()
     request.setThreadidsList(ids)
     const keys = new Map<ThreadID, Uint8Array | undefined>() // replicator key cache

--- a/packages/network/src/network.spec.ts
+++ b/packages/network/src/network.spec.ts
@@ -6,7 +6,7 @@ import { randomBytes } from 'libp2p-crypto'
 import { expect } from 'chai'
 import PeerId from 'peer-id'
 import { keys } from 'libp2p-crypto'
-import { ThreadID, Variant, ThreadInfo, Block, ThreadRecord, Multiaddr, Key } from '@textile/threads-core'
+import { ThreadID, ThreadInfo, Block, ThreadRecord, Multiaddr, Key } from '@textile/threads-core'
 import { createEvent, createRecord } from '@textile/threads-encoding'
 import { Client } from '@textile/threads-network-client'
 import { MemoryDatastore } from 'interface-datastore'
@@ -17,14 +17,14 @@ const proxyAddr2 = 'http://127.0.0.1:6207'
 const ed25519 = keys.supportedKeys.ed25519
 
 async function createThread(client: Network) {
-  const id = ThreadID.fromRandom(Variant.Raw, 32)
+  const id = ThreadID.fromRandom(ThreadID.Variant.Raw, 32)
   const threadKey = Key.fromRandom()
   return client.createThread(id, { threadKey })
 }
 
 function threadAddr(hostAddr: Multiaddr, hostID: PeerId, info: ThreadInfo) {
   const pa = new Multiaddr(`/p2p/${hostID.toB58String()}`)
-  const ta = new Multiaddr(`/thread/${info.id.string()}`)
+  const ta = new Multiaddr(`/thread/${info.id.toString()}`)
   return hostAddr.encapsulate(pa.encapsulate(ta)) as any
 }
 
@@ -40,10 +40,10 @@ describe('Network...', () => {
     })
 
     it('should create a remote thread', async () => {
-      const id = ThreadID.fromRandom(Variant.Raw, 32)
+      const id = ThreadID.fromRandom(ThreadID.Variant.Raw, 32)
       const threadKey = Key.fromRandom()
       const info = await client.createThread(id, { threadKey })
-      expect(info.id.string()).to.equal(id.string())
+      expect(info.id.toString()).to.equal(id.toString())
       expect(info.key?.read).to.not.be.undefined
       expect(info.key?.service).to.not.be.undefined
     })
@@ -55,13 +55,13 @@ describe('Network...', () => {
       const addr = threadAddr(hostAddr, hostID, info1)
       const client2 = new Client({ host: proxyAddr2 })
       const info2 = await client2.addThread(addr, { threadKey: info1.key })
-      expect(info2.id.string()).to.equal(info1.id.string())
+      expect(info2.id.toString()).to.equal(info1.id.toString())
     })
 
     it('should add and then get a remote thread', async () => {
       const info1 = await createThread(client)
       const info2 = await client.getThread(info1.id)
-      expect(info2.id.string()).to.equal(info1.id.string())
+      expect(info2.id.toString()).to.equal(info1.id.toString())
     })
 
     it('should pull a thread for records', async () => {
@@ -99,7 +99,7 @@ describe('Network...', () => {
       const info = await createThread(client)
       const body = { foo: 'bar', baz: Buffer.from('howdy') }
       const rec = await client.createRecord(info.id, body)
-      expect(rec?.threadID.string()).to.equal(info.id.string())
+      expect(rec?.threadID.toString()).to.equal(info.id.toString())
       expect(rec?.logID).to.not.be.undefined
       if (rec?.record) {
         const block = rec.record.block
@@ -111,7 +111,7 @@ describe('Network...', () => {
 
     it('should be able to add a pre-formed record', async () => {
       // Create a thread, keeping read key and log private key on the client
-      const id = ThreadID.fromRandom(Variant.Raw, 32)
+      const id = ThreadID.fromRandom(ThreadID.Variant.Raw, 32)
       const threadKey = Key.fromRandom(false)
       const privKey = await ed25519.generateKeyPair()
       const logKey = privKey.public

--- a/packages/network/src/network.ts
+++ b/packages/network/src/network.ts
@@ -109,7 +109,7 @@ export class Network implements Interface {
    * @param id The Thread ID.
    */
   async pullThread(id: ThreadID) {
-    logger.debug(`pulling thread ${id.string()}`)
+    logger.debug(`pulling thread ${id.toString()}`)
     // @note: Not need to worry about safety here, the remote peer will handle that for us.
     return this.client.pullThread(id)
   }

--- a/packages/network/src/store/keybook.ts
+++ b/packages/network/src/store/keybook.ts
@@ -13,7 +13,7 @@ import PeerId from 'peer-id'
 const baseKey = new Key('/thread/keys')
 const getKey = (id: ThreadID, log: LogID, suffix?: string) => {
   const idString = log.toB58String()
-  return new Key(id.string()).child(new Key(suffix ? `${idString}:${suffix}` : idString))
+  return new Key(id.toString()).child(new Key(suffix ? `${idString}:${suffix}` : idString))
 }
 
 /**
@@ -87,7 +87,7 @@ export class KeyBook implements Closer {
    */
   async readKey(id: ThreadID) {
     try {
-      return await this.datastore.get(new Key(id.string()).child(new Key('read')))
+      return await this.datastore.get(new Key(id.toString()).child(new Key('read')))
     } catch (err) {
       return
     }
@@ -99,7 +99,7 @@ export class KeyBook implements Closer {
    * @param key The asymmetric read key, of length 44 bytes.
    */
   addReadKey(id: ThreadID, key: Buffer) {
-    return this.datastore.put(new Key(id.string()).child(new Key('read')), key)
+    return this.datastore.put(new Key(id.toString()).child(new Key('read')), key)
   }
 
   /**
@@ -107,7 +107,7 @@ export class KeyBook implements Closer {
    */
   async serviceKey(id: ThreadID) {
     try {
-      return await this.datastore.get(new Key(id.string()).child(new Key('repl')))
+      return await this.datastore.get(new Key(id.toString()).child(new Key('repl')))
     } catch (err) {
       return
     }
@@ -119,7 +119,7 @@ export class KeyBook implements Closer {
    * @param key The asymmetric replicator key, of length 44 bytes.
    */
   addServiceKey(id: ThreadID, key: Buffer) {
-    return this.datastore.put(new Key(id.string()).child(new Key('repl')), key)
+    return this.datastore.put(new Key(id.toString()).child(new Key('repl')), key)
   }
 
   async threads() {
@@ -130,7 +130,7 @@ export class KeyBook implements Closer {
     })) {
       // We only care about threads we can replicate
       if (key.name() === 'repl') {
-        threads.add(ThreadID.fromEncoded(key.parent().toString()))
+        threads.add(ThreadID.fromString(key.parent().toString()))
       }
     }
     return threads
@@ -138,7 +138,7 @@ export class KeyBook implements Closer {
 
   async logs(id: ThreadID): Promise<Set<LogID>> {
     const logs = new Set<LogID>()
-    const q = { keysOnly: true, prefix: id.string() }
+    const q = { keysOnly: true, prefix: id.toString() }
     for await (const { key } of this.datastore.query(q)) {
       if (['priv', 'pub'].includes(key.name())) {
         const log = PeerId.createFromB58String(key.type())


### PR DESCRIPTION
Signed-off-by: Carson Farmer <carson.farmer@gmail.com>

## Description

This changes the usage of `ThreadID` from things like `string()` to `toString()` and makes base32 encoding the default for `toString()`

Fixes #32 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

All existing tests have been run locally and are passing, including tsc and linter checks.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

