### PR TITLE
Fixes some dep compile issues

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,6 +1,6 @@
 {
   "diff": true,
-  "spec": "packages/*/src/**.spec.ts",
+  "spec": "packages/*/src/**/*.spec.ts",
   "reporter": "spec",
   "recursive": true,
   "require": [

--- a/packages/database/src/collection.ts
+++ b/packages/database/src/collection.ts
@@ -2,11 +2,13 @@ import { Datastore, Key, MemoryDatastore, Query } from 'interface-datastore'
 import Ajv, { ValidateFunction, ValidationError } from 'ajv'
 import { ulid } from 'ulid'
 import { reduce } from 'streaming-iterables'
-import { Query as MingoQuery } from 'mingo/query'
-import { resolve } from 'mingo/util'
+import { Query as MingoQuery } from 'mingo'
 import { JSONSchema4, JSONSchema6, JSONSchema7 } from 'json-schema'
 import { Dispatcher, Instance, JsonPatchStore } from '@textile/threads-store'
 import { FilterQuery } from './query'
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { resolve } = require('mingo/util')
 
 export { FilterQuery }
 

--- a/packages/network/package-lock.json
+++ b/packages/network/package-lock.json
@@ -4,199 +4,6 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@consento/sync-randombytes": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@consento/sync-randombytes/-/sync-randombytes-1.0.5.tgz",
-			"integrity": "sha512-mPJ2XvrTLQGEdhleDuSIkWtVWnvmhREOC1FjorV1nlK49t/52Z9X1d618gTj6nlQghRLiYvcd8oL4vZ2YZuDIQ==",
-			"requires": {
-				"buffer": "^5.4.3",
-				"seedrandom": "^3.0.5"
-			}
-		},
-		"@improbable-eng/grpc-web": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/@improbable-eng/grpc-web/-/grpc-web-0.12.0.tgz",
-			"integrity": "sha512-uJjgMPngreRTYPBuo6gswMj1gK39Wbqre/RgE0XnSDXJRg6ST7ZhuS53dFE6Vc2CX4jxgl+cO+0B3op8LA4Q0Q==",
-			"requires": {
-				"browser-headers": "^0.4.0"
-			}
-		},
-		"@ipld/block": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@ipld/block/-/block-4.0.2.tgz",
-			"integrity": "sha512-O041EI8D3hOws5PqRsiQpeOSAwtkm4z/EfBHPszwR/qd353h6GQ0uiAV/Qru1dWYN+eR5z37/KpnrM3iLCKPjA==",
-			"requires": {
-				"@ipld/get-codec": "^4.0.0",
-				"buffer": "^5.6.0",
-				"cids": "~0.8.0",
-				"class-is": "^1.1.0",
-				"lodash.transform": "^4.6.0",
-				"multihashing-async": "^0.8.1"
-			}
-		},
-		"@ipld/codec-interface": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@ipld/codec-interface/-/codec-interface-1.0.8.tgz",
-			"integrity": "sha512-qidYsyxc2miM4auojdwQhAdqYucjiz0IsoklCRXv0lnl625YvkVBSCeKrrpivQX4R0jZEM34V5qnvzRMksO+Fg==",
-			"requires": {
-				"cids": "~0.7.2"
-			},
-			"dependencies": {
-				"cids": {
-					"version": "0.7.5",
-					"resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
-					"integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
-					"requires": {
-						"buffer": "^5.5.0",
-						"class-is": "^1.1.0",
-						"multibase": "~0.6.0",
-						"multicodec": "^1.0.0",
-						"multihashes": "~0.4.15"
-					}
-				},
-				"multibase": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
-					"integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
-					"requires": {
-						"base-x": "^3.0.8",
-						"buffer": "^5.5.0"
-					}
-				}
-			}
-		},
-		"@ipld/dag-json": {
-			"version": "2.0.9",
-			"resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-2.0.9.tgz",
-			"integrity": "sha512-0SjSYa7ZloILvi7hoJvSxmbpamofsWMePmIn9cCw+EYYm+WSFxbpn1rfYOSlvkdbAutAXO7BBtUnhr3MYD/KPA==",
-			"requires": {
-				"@ipld/codec-interface": "^1.0.8",
-				"cids": "~0.7.3",
-				"fast-json-stable-stringify": "^2.1.0",
-				"is-circular": "^1.0.2",
-				"lodash.transform": "^4.6.0"
-			},
-			"dependencies": {
-				"cids": {
-					"version": "0.7.5",
-					"resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
-					"integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
-					"requires": {
-						"buffer": "^5.5.0",
-						"class-is": "^1.1.0",
-						"multibase": "~0.6.0",
-						"multicodec": "^1.0.0",
-						"multihashes": "~0.4.15"
-					}
-				},
-				"multibase": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
-					"integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
-					"requires": {
-						"base-x": "^3.0.8",
-						"buffer": "^5.5.0"
-					}
-				}
-			}
-		},
-		"@ipld/get-codec": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@ipld/get-codec/-/get-codec-4.0.0.tgz",
-			"integrity": "sha512-HXxM2BUP0ZVUvYlAINGUIZcrpynSmlVU335ENLXPLOrAZBk3gueIcGyCHqCCrJ1Lu8EhCVo14gAjCEZM6DFYVg==",
-			"requires": {
-				"@ipld/codec-interface": "^1.0.5",
-				"@ipld/dag-json": "^2.0.4",
-				"buffer": "^5.5.0",
-				"ipld-bitcoin": "~0.3.0",
-				"ipld-dag-cbor": "~0.15.0",
-				"ipld-dag-pb": "~0.18.1",
-				"ipld-git": "~0.5.0",
-				"ipld-zcash": "~0.4.0",
-				"multicodec": "^1.0.0"
-			}
-		},
-		"@textile/multiaddr": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/@textile/multiaddr/-/multiaddr-0.0.3.tgz",
-			"integrity": "sha512-naeaz74IbjtmmZpj5VImr+HQUQrU3YwJ0mH0c4kPbZuADPgxVzVFhQPVt6esc3TZwovPbNVUjJuwLbBCg7L5jw==",
-			"requires": {
-				"@textile/threads-id": "^0.0.3",
-				"@types/multibase": "^0.6.0",
-				"bs58": "^4.0.1",
-				"cids": "^0.8.0",
-				"multiaddr": "^7.4.2",
-				"varint": "^5.0.0"
-			}
-		},
-		"@textile/threads-core": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/@textile/threads-core/-/threads-core-0.1.5.tgz",
-			"integrity": "sha512-zwq+R7ULHm5MO5gpmnsrL8LelU1tLBeBEV0sRYHNT0Fz5+kFMGuHCHrU99gXdwOUTKbaOvH9hhkh0PglCsXQBQ==",
-			"requires": {
-				"@ipld/block": "^4.0.0",
-				"@textile/multiaddr": "^0.0.3",
-				"@textile/threads-id": "^0.0.3",
-				"@types/multibase": "^0.6.0",
-				"@types/node": "^13.9.2",
-				"bs58": "^4.0.1",
-				"libp2p-crypto": "^0.17.2",
-				"multiaddr": "^7.4.2",
-				"multibase": "^0.7.0",
-				"peer-id": "^0.13.11",
-				"varint": "^5.0.0"
-			}
-		},
-		"@textile/threads-encoding": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/@textile/threads-encoding/-/threads-encoding-0.1.5.tgz",
-			"integrity": "sha512-E+fYqGQ0ZyzrCKWe6MhU2ITHyoAL0396Fz2pcNwxJhuX5aHAhPxC+DljrmsJMjes1QIRbb9cQ1bKh8alUBOjMQ==",
-			"requires": {
-				"@ipld/block": "^4.0.0",
-				"@textile/threads-core": "^0.1.5",
-				"@types/node": "^13.9.2",
-				"cids": "^0.8.0",
-				"libp2p-crypto": "^0.17.2",
-				"loglevel": "^1.6.6"
-			}
-		},
-		"@textile/threads-id": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/@textile/threads-id/-/threads-id-0.0.3.tgz",
-			"integrity": "sha512-TLi9ecmRd9t44HIWV/GTOVkmc4wXyxElWdSgzEai89PJFSp4XAeb29QWknepTiyv0+h+4YNXvoKQAWeWMgO0+g==",
-			"requires": {
-				"@consento/sync-randombytes": "^1.0.4",
-				"@types/node": "^13.9.2",
-				"multibase": "^0.7.0",
-				"varint": "^5.0.0"
-			}
-		},
-		"@textile/threads-net-grpc": {
-			"version": "0.1.17",
-			"resolved": "https://registry.npmjs.org/@textile/threads-net-grpc/-/threads-net-grpc-0.1.17.tgz",
-			"integrity": "sha512-WPw5XHU0fV7my1pXT8hku91jsw3TGmo5o5tDe2idXoUN/mKFP+g40nx8K3rqWe7dRryDsNhJZJVE89QblQYoxg==",
-			"requires": {
-				"@improbable-eng/grpc-web": "^0.12.0",
-				"@types/google-protobuf": "^3.7.2",
-				"google-protobuf": "^3.11.2"
-			}
-		},
-		"@textile/threads-network-client": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/@textile/threads-network-client/-/threads-network-client-0.1.5.tgz",
-			"integrity": "sha512-OC3rWOPW1fX7t4CGJYDoCDtN7gOstKehi7qDQkCEN9C3Xk5UoCtOHtVhZGxK1j7pJvMQzXwPiTdwJo4mgPzqrg==",
-			"requires": {
-				"@improbable-eng/grpc-web": "^0.12.0",
-				"@textile/threads-core": "^0.1.5",
-				"@textile/threads-encoding": "^0.1.5",
-				"@textile/threads-net-grpc": "^0.1.16",
-				"cids": "^0.8.0",
-				"libp2p-crypto": "^0.17.2",
-				"loglevel": "^1.6.6",
-				"next-tick": "^1.1.0",
-				"peer-id": "^0.13.9"
-			}
-		},
 		"@types/datastore-core": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/@types/datastore-core/-/datastore-core-0.7.0.tgz",
@@ -206,24 +13,11 @@
 				"@types/interface-datastore": "*"
 			}
 		},
-		"@types/google-protobuf": {
-			"version": "3.7.2",
-			"resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.7.2.tgz",
-			"integrity": "sha512-ifFemzjNchFBCtHS6bZNhSZCBu7tbtOe0e8qY0z2J4HtFXmPJjm6fXSaQsTG7yhShBEZtt2oP/bkwu5k+emlkQ=="
-		},
 		"@types/interface-datastore": {
 			"version": "0.8.0",
 			"resolved": "https://registry.npmjs.org/@types/interface-datastore/-/interface-datastore-0.8.0.tgz",
 			"integrity": "sha512-apbO3UBpzuqIB/QjvClc7tXOH3m2HYWhYqSBS3dycLrULIqk6dNVUkkI7WI3hXXUEW6YcQAkj6IDMm4A2ERhTg==",
 			"dev": true,
-			"requires": {
-				"@types/node": "*"
-			}
-		},
-		"@types/multibase": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/@types/multibase/-/multibase-0.6.0.tgz",
-			"integrity": "sha512-PhQiA4pCcIG5yibX/G7K7mk/CXw0HTY98R+efcbbfce9WOyAGbIVqY3zv5kMm+vMAunY29aeOtQ96ePjeX417w==",
 			"requires": {
 				"@types/node": "*"
 			}
@@ -289,83 +83,12 @@
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
 			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
 		},
-		"bech32": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-			"integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
-		},
-		"bignumber.js": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
-			"integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
-		},
 		"bindings": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
 			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
 			"requires": {
 				"file-uri-to-path": "1.0.0"
-			}
-		},
-		"bip174": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/bip174/-/bip174-1.0.1.tgz",
-			"integrity": "sha512-Mq2aFs1TdMfxBpYPg7uzjhsiXbAtoVq44TNjEWtvuZBiBgc3m7+n55orYMtTAxdg7jWbL4DtH0MKocJER4xERQ=="
-		},
-		"bip32": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/bip32/-/bip32-2.0.5.tgz",
-			"integrity": "sha512-zVY4VvJV+b2fS0/dcap/5XLlpqtgwyN8oRkuGgAS1uLOeEp0Yo6Tw2yUTozTtlrMJO3G8n4g/KX/XGFHW6Pq3g==",
-			"requires": {
-				"@types/node": "10.12.18",
-				"bs58check": "^2.1.1",
-				"create-hash": "^1.2.0",
-				"create-hmac": "^1.1.7",
-				"tiny-secp256k1": "^1.1.3",
-				"typeforce": "^1.11.5",
-				"wif": "^2.0.6"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "10.12.18",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
-					"integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
-				}
-			}
-		},
-		"bip66": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-			"integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"bitcoin-ops": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz",
-			"integrity": "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow=="
-		},
-		"bitcoinjs-lib": {
-			"version": "5.1.7",
-			"resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-5.1.7.tgz",
-			"integrity": "sha512-sNlTQuvhaoIjOdIdyENsX74Dlikv7l6AzO0/uZQscuvfBID6aMANoCz1rooCTH5upTV5rKCj4z3BXBmXJxq23g==",
-			"requires": {
-				"bech32": "^1.1.2",
-				"bip174": "^1.0.1",
-				"bip32": "^2.0.4",
-				"bip66": "^1.1.0",
-				"bitcoin-ops": "^1.4.0",
-				"bs58check": "^2.0.0",
-				"create-hash": "^1.1.0",
-				"create-hmac": "^1.1.3",
-				"merkle-lib": "^2.0.10",
-				"pushdata-bitcoin": "^1.0.1",
-				"randombytes": "^2.0.1",
-				"tiny-secp256k1": "^1.1.1",
-				"typeforce": "^1.11.3",
-				"varuint-bitcoin": "^1.0.4",
-				"wif": "^2.0.1"
 			}
 		},
 		"blakejs": {
@@ -377,20 +100,6 @@
 			"version": "4.11.8",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
 			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
-		},
-		"borc": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
-			"integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
-			"requires": {
-				"bignumber.js": "^9.0.0",
-				"buffer": "^5.5.0",
-				"commander": "^2.15.0",
-				"ieee754": "^1.1.13",
-				"iso-url": "~0.4.7",
-				"json-text-sequence": "~0.1.0",
-				"readable-stream": "^3.6.0"
-			}
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -406,94 +115,6 @@
 			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
 			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
 		},
-		"browser-headers": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/browser-headers/-/browser-headers-0.4.1.tgz",
-			"integrity": "sha512-CA9hsySZVo9371qEHjHZtYxV2cFtVj5Wj/ZHi8ooEsrtm4vOnl9Y9HmyYWk9q+05d7K3rdoAE0j3MVEFVvtQtg=="
-		},
-		"browserify-aes": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
-			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
-			"requires": {
-				"buffer-xor": "^1.0.3",
-				"cipher-base": "^1.0.0",
-				"create-hash": "^1.1.0",
-				"evp_bytestokey": "^1.0.3",
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"browserify-cipher": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
-			"integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
-			"requires": {
-				"browserify-aes": "^1.0.4",
-				"browserify-des": "^1.0.0",
-				"evp_bytestokey": "^1.0.0"
-			}
-		},
-		"browserify-des": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
-			"integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
-			"requires": {
-				"cipher-base": "^1.0.1",
-				"des.js": "^1.0.0",
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.1.2"
-			}
-		},
-		"browserify-rsa": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
-			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
-			"requires": {
-				"bn.js": "^4.1.0",
-				"randombytes": "^2.0.1"
-			}
-		},
-		"browserify-sign": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.1.0.tgz",
-			"integrity": "sha512-VYxo7cDCeYUoBZ0ZCy4UyEUCP3smyBd4DRQM5nrFS1jJjPJjX7rP3oLRpPoWfkhQfyJ0I9ZbHbKafrFD/SGlrg==",
-			"requires": {
-				"bn.js": "^5.1.1",
-				"browserify-rsa": "^4.0.1",
-				"create-hash": "^1.2.0",
-				"create-hmac": "^1.1.7",
-				"elliptic": "^6.5.2",
-				"inherits": "^2.0.4",
-				"parse-asn1": "^5.1.5",
-				"readable-stream": "^3.6.0"
-			},
-			"dependencies": {
-				"bn.js": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.1.tgz",
-					"integrity": "sha512-IUTD/REb78Z2eodka1QZyyEk66pciRcP6Sroka0aI3tG/iwIdYLrBD62RsubR7vqdt3WyX8p4jxeatzmRSphtA=="
-				}
-			}
-		},
-		"bs58": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-			"integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
-			"requires": {
-				"base-x": "^3.0.2"
-			}
-		},
-		"bs58check": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
-			"integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
-			"requires": {
-				"bs58": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"safe-buffer": "^5.1.2"
-			}
-		},
 		"buffer": {
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
@@ -502,11 +123,6 @@
 				"base64-js": "^1.0.2",
 				"ieee754": "^1.1.4"
 			}
-		},
-		"buffer-xor": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
 		},
 		"cids": {
 			"version": "0.8.0",
@@ -520,81 +136,15 @@
 				"multihashes": "~0.4.17"
 			}
 		},
-		"cipher-base": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-			"requires": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
-			}
-		},
 		"class-is": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
 			"integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw=="
 		},
-		"commander": {
-			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-		},
-		"create-ecdh": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
-			"integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
-			"requires": {
-				"bn.js": "^4.1.0",
-				"elliptic": "^6.0.0"
-			}
-		},
-		"create-hash": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-			"requires": {
-				"cipher-base": "^1.0.1",
-				"inherits": "^2.0.1",
-				"md5.js": "^1.3.4",
-				"ripemd160": "^2.0.1",
-				"sha.js": "^2.4.0"
-			}
-		},
-		"create-hmac": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-			"requires": {
-				"cipher-base": "^1.0.3",
-				"create-hash": "^1.1.0",
-				"inherits": "^2.0.1",
-				"ripemd160": "^2.0.0",
-				"safe-buffer": "^5.0.1",
-				"sha.js": "^2.4.8"
-			}
-		},
-		"crypto-browserify": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-			"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
-			"requires": {
-				"browserify-cipher": "^1.0.0",
-				"browserify-sign": "^4.0.0",
-				"create-ecdh": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"create-hmac": "^1.1.0",
-				"diffie-hellman": "^5.0.0",
-				"inherits": "^2.0.1",
-				"pbkdf2": "^3.0.3",
-				"public-encrypt": "^4.0.0",
-				"randombytes": "^2.0.0",
-				"randomfill": "^1.0.3"
-			}
 		},
 		"datastore-core": {
 			"version": "1.1.0",
@@ -650,35 +200,6 @@
 				"ms": "^2.1.1"
 			}
 		},
-		"delimit-stream": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
-			"integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs="
-		},
-		"des.js": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
-			"integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
-			"requires": {
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0"
-			}
-		},
-		"detect-node": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
-			"integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
-		},
-		"diffie-hellman": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
-			"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
-			"requires": {
-				"bn.js": "^4.1.0",
-				"miller-rabin": "^4.0.0",
-				"randombytes": "^2.0.0"
-			}
-		},
 		"elliptic": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
@@ -702,20 +223,6 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
 			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
-		},
-		"evp_bytestokey": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
-			"requires": {
-				"md5.js": "^1.3.4",
-				"safe-buffer": "^5.1.1"
-			}
-		},
-		"fast-json-stable-stringify": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
 		},
 		"file-uri-to-path": {
 			"version": "1.0.0",
@@ -758,25 +265,10 @@
 				"path-is-absolute": "^1.0.0"
 			}
 		},
-		"google-protobuf": {
-			"version": "3.11.4",
-			"resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.11.4.tgz",
-			"integrity": "sha512-lL6b04rDirurUBOgsY2+LalI6Evq8eH5TcNzi7TYQ3BsIWelT0KSOQSBsXuavEkNf+odQU6c0lgz3UsZXeNX9Q=="
-		},
 		"graceful-fs": {
 			"version": "4.2.4",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
 			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
-		},
-		"hash-base": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
-			"integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
-			"requires": {
-				"inherits": "^2.0.4",
-				"readable-stream": "^3.6.0",
-				"safe-buffer": "^5.2.0"
-			}
 		},
 		"hash.js": {
 			"version": "1.1.7",
@@ -830,11 +322,6 @@
 				"nanoid": "^3.0.2"
 			}
 		},
-		"ip-regex": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.1.0.tgz",
-			"integrity": "sha512-pKnZpbgCTfH/1NLIlOduP/V+WRXzC2MOz3Qo8xmxk8C5GudJLgK5QyLVXOSWy3ParAH7Eemurl3xjv/WXYFvMA=="
-		},
 		"ipfs-utils": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-1.2.4.tgz",
@@ -860,156 +347,10 @@
 				}
 			}
 		},
-		"ipld-bitcoin": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/ipld-bitcoin/-/ipld-bitcoin-0.3.1.tgz",
-			"integrity": "sha512-0ysHoWyT+xXNyDafZrlH6YHGXWKkZ392eOardFTl2c9EUXDOt2W8VNaWol8ZyYSlD1nELwNLjC4e7p8aBY/OEg==",
-			"requires": {
-				"bitcoinjs-lib": "^5.0.0",
-				"cids": "~0.7.0",
-				"multicodec": "^1.0.0",
-				"multihashes": "~0.4.14",
-				"multihashing-async": "~0.8.0"
-			},
-			"dependencies": {
-				"cids": {
-					"version": "0.7.5",
-					"resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
-					"integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
-					"requires": {
-						"buffer": "^5.5.0",
-						"class-is": "^1.1.0",
-						"multibase": "~0.6.0",
-						"multicodec": "^1.0.0",
-						"multihashes": "~0.4.15"
-					}
-				},
-				"multibase": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
-					"integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
-					"requires": {
-						"base-x": "^3.0.8",
-						"buffer": "^5.5.0"
-					}
-				}
-			}
-		},
-		"ipld-dag-cbor": {
-			"version": "0.15.2",
-			"resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.15.2.tgz",
-			"integrity": "sha512-Ioni4s959P/CtkWQOt1TXrj4zqc3MoPxvHrEmybCn5JFdG3dpBNJR1oBVvP6uUrmF5bBtUGKNbX1pSI5SEOaHg==",
-			"requires": {
-				"borc": "^2.1.2",
-				"buffer": "^5.5.0",
-				"cids": "~0.8.0",
-				"is-circular": "^1.0.2",
-				"multicodec": "^1.0.0",
-				"multihashing-async": "~0.8.0"
-			}
-		},
-		"ipld-dag-pb": {
-			"version": "0.18.5",
-			"resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.18.5.tgz",
-			"integrity": "sha512-8IAPZrkRjgTpkxV9JOwXSBe0GXNxd4B2lubPgbifTGL92rZOEKWutpijsWsWvjXOltDFHKMQIIIhkgLC5RPqbA==",
-			"requires": {
-				"buffer": "^5.6.0",
-				"cids": "~0.8.0",
-				"class-is": "^1.1.0",
-				"multicodec": "^1.0.1",
-				"multihashing-async": "~0.8.1",
-				"protons": "^1.0.2",
-				"stable": "^0.1.8"
-			}
-		},
-		"ipld-git": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/ipld-git/-/ipld-git-0.5.1.tgz",
-			"integrity": "sha512-041Hq9hEjgzGue46lkPoBD6rEO+YCj04JFXVRGxd7AdacGrx3rV62uz/zUXfkncNZ/mjpovycZ+MC4skbO/43w==",
-			"requires": {
-				"cids": "~0.7.0",
-				"multicodec": "^1.0.0",
-				"multihashes": "~0.4.14",
-				"multihashing-async": "~0.8.0",
-				"smart-buffer": "^4.0.2",
-				"strftime": "~0.10.0"
-			},
-			"dependencies": {
-				"cids": {
-					"version": "0.7.5",
-					"resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
-					"integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
-					"requires": {
-						"buffer": "^5.5.0",
-						"class-is": "^1.1.0",
-						"multibase": "~0.6.0",
-						"multicodec": "^1.0.0",
-						"multihashes": "~0.4.15"
-					}
-				},
-				"multibase": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
-					"integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
-					"requires": {
-						"base-x": "^3.0.8",
-						"buffer": "^5.5.0"
-					}
-				}
-			}
-		},
-		"ipld-zcash": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/ipld-zcash/-/ipld-zcash-0.4.1.tgz",
-			"integrity": "sha512-1JNnY0HuLeJDzlRJSKxs8laZ+TKPr8zui7GNiJMHgMIjH7KOiVjAQfO7Rt7KzDucMLYPokarfIPaK3qeffwI2A==",
-			"requires": {
-				"cids": "~0.7.1",
-				"multicodec": "^1.0.0",
-				"multihashes": "~0.4.15",
-				"multihashing-async": "~0.8.0",
-				"zcash-block": "^2.0.0"
-			},
-			"dependencies": {
-				"cids": {
-					"version": "0.7.5",
-					"resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
-					"integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
-					"requires": {
-						"buffer": "^5.5.0",
-						"class-is": "^1.1.0",
-						"multibase": "~0.6.0",
-						"multicodec": "^1.0.0",
-						"multihashes": "~0.4.15"
-					}
-				},
-				"multibase": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
-					"integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
-					"requires": {
-						"base-x": "^3.0.8",
-						"buffer": "^5.5.0"
-					}
-				}
-			}
-		},
-		"is-circular": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-circular/-/is-circular-1.0.2.tgz",
-			"integrity": "sha512-YttjnrswnUYRVJvxCvu8z+PGMUSzC2JttP0OEXezlAEdp3EXzhf7IZ3j0gRAybJBQupedIZFhY61Tga6E0qASA=="
-		},
 		"is-electron": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.0.tgz",
 			"integrity": "sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q=="
-		},
-		"is-ip": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
-			"integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
-			"requires": {
-				"ip-regex": "^4.0.0"
-			}
 		},
 		"is-plain-obj": {
 			"version": "2.1.0",
@@ -1090,14 +431,6 @@
 			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
 			"integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
 		},
-		"json-text-sequence": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
-			"integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
-			"requires": {
-				"delimit-stream": "0.1.0"
-			}
-		},
 		"jsonfile": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
@@ -1131,25 +464,10 @@
 				"ursa-optional": "~0.10.1"
 			}
 		},
-		"lodash.transform": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/lodash.transform/-/lodash.transform-4.6.0.tgz",
-			"integrity": "sha1-EjBkIvYzJK7YSD0/ODMrX2cFR6A="
-		},
 		"loglevel": {
 			"version": "1.6.8",
 			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.8.tgz",
 			"integrity": "sha512-bsU7+gc9AJ2SqpzxwU3+1fedl8zAntbtC5XYlt3s2j1hJcn2PsXSmgN8TaLG/J1/2mod4+cE/3vNL70/c1RNCA=="
-		},
-		"md5.js": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-			"integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-			"requires": {
-				"hash-base": "^3.0.0",
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.1.2"
-			}
 		},
 		"merge-options": {
 			"version": "2.0.0",
@@ -1157,20 +475,6 @@
 			"integrity": "sha512-S7xYIeWHl2ZUKF7SDeBhGg6rfv5bKxVBdk95s/I7wVF8d+hjLSztJ/B271cnUiF6CAFduEQ5Zn3HYwAjT16DlQ==",
 			"requires": {
 				"is-plain-obj": "^2.0.0"
-			}
-		},
-		"merkle-lib": {
-			"version": "2.0.10",
-			"resolved": "https://registry.npmjs.org/merkle-lib/-/merkle-lib-2.0.10.tgz",
-			"integrity": "sha1-grjbrnXieneFOItz+ddyXQ9vMyY="
-		},
-		"miller-rabin": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-			"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
-			"requires": {
-				"bn.js": "^4.0.0",
-				"brorand": "^1.0.1"
 			}
 		},
 		"minimalistic-assert": {
@@ -1201,19 +505,6 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
-		"multiaddr": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-7.4.3.tgz",
-			"integrity": "sha512-gFjXmjcCMyrx5KF1QOohUQm6a3E2XF4kydvClS8DmRJkY3qJaDPNNe0OC7mWvVUE0nnE8HjyToQfABnpKClXRA==",
-			"requires": {
-				"buffer": "^5.5.0",
-				"cids": "~0.8.0",
-				"class-is": "^1.1.0",
-				"is-ip": "^3.1.0",
-				"multibase": "^0.7.0",
-				"varint": "^5.0.0"
-			}
-		},
 		"multibase": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
@@ -1240,17 +531,6 @@
 				"buffer": "^5.5.0",
 				"multibase": "^0.7.0",
 				"varint": "^5.0.0"
-			}
-		},
-		"multihashing": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/multihashing/-/multihashing-0.3.3.tgz",
-			"integrity": "sha512-jXVWf5uqnZUhc1mLFPWOssuOpkj/A/vVLKrtEscD1PzSLobXYocBy9Gqa/Aw4229/heGnl0RBHU3cD53MbHUig==",
-			"requires": {
-				"blakejs": "^1.1.0",
-				"js-sha3": "~0.8.0",
-				"multihashes": "~0.4.14",
-				"webcrypto": "~0.1.1"
 			}
 		},
 		"multihashing-async": {
@@ -1284,7 +564,8 @@
 		"next-tick": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-			"integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+			"integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+			"dev": true
 		},
 		"node-addon-api": {
 			"version": "2.0.0",
@@ -1320,48 +601,11 @@
 			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
 			"integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
 		},
-		"parse-asn1": {
-			"version": "5.1.5",
-			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
-			"integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
-			"requires": {
-				"asn1.js": "^4.0.0",
-				"browserify-aes": "^1.0.0",
-				"create-hash": "^1.1.0",
-				"evp_bytestokey": "^1.0.0",
-				"pbkdf2": "^3.0.3",
-				"safe-buffer": "^5.1.1"
-			},
-			"dependencies": {
-				"asn1.js": {
-					"version": "4.10.1",
-					"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-					"integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
-					"requires": {
-						"bn.js": "^4.0.0",
-						"inherits": "^2.0.1",
-						"minimalistic-assert": "^1.0.0"
-					}
-				}
-			}
-		},
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 			"dev": true
-		},
-		"pbkdf2": {
-			"version": "3.0.17",
-			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
-			"integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
-			"requires": {
-				"create-hash": "^1.1.2",
-				"create-hmac": "^1.1.4",
-				"ripemd160": "^2.0.1",
-				"safe-buffer": "^5.0.1",
-				"sha.js": "^2.4.8"
-			}
 		},
 		"peer-id": {
 			"version": "0.13.12",
@@ -1401,44 +645,6 @@
 				"varint": "^5.0.0"
 			}
 		},
-		"public-encrypt": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
-			"integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
-			"requires": {
-				"bn.js": "^4.1.0",
-				"browserify-rsa": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"parse-asn1": "^5.0.0",
-				"randombytes": "^2.0.1",
-				"safe-buffer": "^5.1.2"
-			}
-		},
-		"pushdata-bitcoin": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/pushdata-bitcoin/-/pushdata-bitcoin-1.0.1.tgz",
-			"integrity": "sha1-FZMdPNlnreUiBvUjqnMxrvfUOvc=",
-			"requires": {
-				"bitcoin-ops": "^1.3.0"
-			}
-		},
-		"randombytes": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-			"requires": {
-				"safe-buffer": "^5.1.0"
-			}
-		},
-		"randomfill": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
-			"integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
-			"requires": {
-				"randombytes": "^2.0.5",
-				"safe-buffer": "^5.1.0"
-			}
-		},
 		"readable-stream": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -1456,15 +662,6 @@
 			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
-			}
-		},
-		"ripemd160": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-			"requires": {
-				"hash-base": "^3.0.0",
-				"inherits": "^2.0.1"
 			}
 		},
 		"safe-buffer": {
@@ -1487,20 +684,6 @@
 				"node-gyp-build": "^4.2.0"
 			}
 		},
-		"seedrandom": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
-			"integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
-		},
-		"sha.js": {
-			"version": "2.4.11",
-			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-			"requires": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
-			}
-		},
 		"signed-varint": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/signed-varint/-/signed-varint-2.0.1.tgz",
@@ -1508,16 +691,6 @@
 			"requires": {
 				"varint": "~5.0.0"
 			}
-		},
-		"smart-buffer": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
-			"integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw=="
-		},
-		"stable": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
-			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
 		},
 		"stream-to-it": {
 			"version": "0.2.0",
@@ -1528,11 +701,6 @@
 				"p-defer": "^3.0.0"
 			}
 		},
-		"strftime": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/strftime/-/strftime-0.10.0.tgz",
-			"integrity": "sha1-s/D6QZKVICpaKJ9ta+n0kJphcZM="
-		},
 		"string_decoder": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -1540,23 +708,6 @@
 			"requires": {
 				"safe-buffer": "~5.2.0"
 			}
-		},
-		"tiny-secp256k1": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.4.tgz",
-			"integrity": "sha512-O7NfGzBdBy/jamehZ1ptutZsh2c+9pq2Pu+KPv75+yzk5/Q/6lppQGMUJucHdRGdkeBcAUeLAOdJInEAZgZ53A==",
-			"requires": {
-				"bindings": "^1.3.0",
-				"bn.js": "^4.11.8",
-				"create-hmac": "^1.1.7",
-				"elliptic": "^6.4.0",
-				"nan": "^2.13.2"
-			}
-		},
-		"typeforce": {
-			"version": "1.18.0",
-			"resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
-			"integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
 		},
 		"typescript": {
 			"version": "3.8.3",
@@ -1588,31 +739,6 @@
 			"resolved": "https://registry.npmjs.org/varint/-/varint-5.0.0.tgz",
 			"integrity": "sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8="
 		},
-		"varuint-bitcoin": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz",
-			"integrity": "sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==",
-			"requires": {
-				"safe-buffer": "^5.1.1"
-			}
-		},
-		"webcrypto": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/webcrypto/-/webcrypto-0.1.1.tgz",
-			"integrity": "sha512-BAvoatS38TbHdyt42ECLroi27NmDh5iea5l5rHC6nZTZjlbJlndrT0FoIiEq7fmPHpmNtP0lMFKVMEKZQFIrGA==",
-			"requires": {
-				"crypto-browserify": "^3.10.0",
-				"detect-node": "^2.0.3"
-			}
-		},
-		"wif": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
-			"integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
-			"requires": {
-				"bs58check": "<3.0.0"
-			}
-		},
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -1624,14 +750,6 @@
 			"resolved": "https://registry.npmjs.org/ws/-/ws-7.2.5.tgz",
 			"integrity": "sha512-C34cIU4+DB2vMyAbmEKossWq2ZQDr6QEyuuCzWrM9zfw1sGc0mYiJ0UnG9zzNykt49C2Fi34hvr2vssFQRS6EA==",
 			"dev": true
-		},
-		"zcash-block": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/zcash-block/-/zcash-block-2.0.0.tgz",
-			"integrity": "sha512-I6pv5b+eGE8CJFmltR+ILHnGcnBO8olV78VicQIaWulMhkomlwDmaMeMshJRLPcnd0FBs58QQVcVNBOT9ojH6Q==",
-			"requires": {
-				"multihashing": "~0.3.3"
-			}
 		}
 	}
 }

--- a/packages/network/src/network.ts
+++ b/packages/network/src/network.ts
@@ -13,6 +13,7 @@ import {
   ThreadID,
   ThreadRecord,
   ThreadOptions,
+  ThreadInfo,
   Identity,
   NewThreadOptions,
 } from '@textile/threads-core'
@@ -74,7 +75,7 @@ export class Network implements Interface {
       logKey: logInfo.pubKey,
       token: opts?.token ?? this.token,
     }
-    const info = await this.client.createThread(id, newOpts)
+    const info: ThreadInfo = await this.client.createThread(id, newOpts)
     // Now we want to store or create read key
     info.key = new ThreadKey(threadKey.service, threadKey.read || randomBytes(32))
     logger.debug('caching thread + log information')
@@ -98,7 +99,7 @@ export class Network implements Interface {
       logKey: logInfo.pubKey,
       token: opts?.token ?? this.token,
     }
-    const info = await this.client.addThread(addr, newOpts)
+    const info: ThreadInfo = await this.client.addThread(addr, newOpts)
     // Now we want to store full key information
     info.key = threadKey
     logger.debug('caching thread + log information')


### PR DESCRIPTION
With the upgrade to mingo 0.3, there were some ES import issues that cropped up due to the way the modules were being imported, this should fix that. It also explicitly defines the types returned from several network layer methods to avoid ambiguous types in external usage.