### PR TITLE
Feature: Expiring context

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,7 +30,12 @@
     "@typescript-eslint/explicit-function-return-type": 0,
     "@typescript-eslint/no-explicit-any": 0,
     "@typescript-eslint/explicit-member-accessibility": 0,
-    "@typescript-eslint/no-unused-vars": [0, {"argsIgnorePattern": "^_"}],
+    "@typescript-eslint/no-unused-vars": [
+      0,
+      {
+        "argsIgnorePattern": "^_"
+      }
+    ],
     "no-undefined": 0,
     "default-case": 0,
     "import/no-absolute-path": 2,

--- a/packages/context/src/index.spec.ts
+++ b/packages/context/src/index.spec.ts
@@ -3,8 +3,8 @@ import { Context, expirationError } from './index'
 
 describe('Context', () => {
   it('should throw an exception when working with an expired msg', async () => {
+    const context = new Context()
     try {
-      const context = new Context()
       context.withAPISig({
         sig: 'fake',
         // Create msg date in the past
@@ -15,5 +15,12 @@ describe('Context', () => {
     } catch (err) {
       expect(err).to.equal(expirationError)
     }
+    const msg = new Date(Date.now() + 1000 * 60).toUTCString()
+    context.withAPISig({
+      sig: 'fake',
+      msg,
+    })
+    const json = context.toJSON()
+    expect(json).to.haveOwnProperty('x-textile-api-sig-msg', msg)
   })
 })

--- a/packages/context/src/index.spec.ts
+++ b/packages/context/src/index.spec.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai'
+import { Context, expirationError } from './index'
+
+describe('Context', () => {
+  it('should throw an exception when working with an expired msg', async () => {
+    try {
+      const context = new Context()
+      context.withAPISig({
+        sig: 'fake',
+        // Create msg date in the past
+        msg: new Date(Date.now() - 1000 * 60).toUTCString(),
+      })
+      context.toJSON()
+      throw new Error('should have thrown')
+    } catch (err) {
+      expect(err).to.equal(expirationError)
+    }
+  })
+})

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -17,6 +17,10 @@ type KeyInfo = {
   type: 0 | 1
 }
 
+export const expirationError = new Error(
+  'Context expired. Consider calling withUserKey or withAPISig to refresh.',
+)
+
 export const createAPISig = async (
   secret: string,
   date: Date = new Date(Date.now() + 1000 * 60),
@@ -183,6 +187,10 @@ export class Context {
   toJSON() {
     // Strip out transport. @todo: phase out transport out entirely
     const { transport, ...context } = this._context
+    const msg = context['x-textile-api-sig-msg']
+    if (msg && new Date(msg) <= new Date()) {
+      throw expirationError
+    }
     return context
   }
 

--- a/typedoc.json
+++ b/typedoc.json
@@ -4,7 +4,10 @@
   "mode": "modules",
   "out": "docs",
   "include": "src/",
-  "exclude": ["**/*.spec.ts", "**/node_modules/**"],
+  "exclude": [
+    "**/*.spec.ts",
+    "**/node_modules/**"
+  ],
   "gitRevision": "master",
   "excludePrivate": true,
   "excludeNotExported": true,


### PR DESCRIPTION
## Description

When a context is expired, this change will automatically throw an error if that context is serialized to JSON, which is commonly done right before usage in any gRPC calls (in converting to metadata).

Fixes #179 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

All existing tests continue to pass, and one additional mini test was added.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
