### PR TITLE
chore(naming): update all dbID to threadID

### DIFF
--- a/packages/client/src/models/ReadTransaction.ts
+++ b/packages/client/src/models/ReadTransaction.ts
@@ -23,17 +23,17 @@ export class ReadTransaction extends Transaction<ReadTransactionRequest, ReadTra
   constructor(
     protected readonly context: ContextInterface,
     protected readonly client: grpc.Client<ReadTransactionRequest, ReadTransactionReply>,
-    protected readonly dbID: ThreadID,
+    protected readonly threadID: ThreadID,
     protected readonly modelName: string,
   ) {
-    super(client, dbID, modelName)
+    super(client, threadID, modelName)
   }
   /**
    * start begins the transaction. All operations between start and end will be applied as a single transaction upon a call to end.
    */
   public async start() {
     const startReq = new StartTransactionRequest()
-    startReq.setDbid(this.dbID.toBytes())
+    startReq.setDbid(this.threadID.toBytes())
     startReq.setCollectionname(this.modelName)
     const req = new ReadTransactionRequest()
     req.setStarttransactionrequest(startReq)

--- a/packages/client/src/models/Transaction.ts
+++ b/packages/client/src/models/Transaction.ts
@@ -16,12 +16,12 @@ export class Transaction<
   /**
    * Transaction creates a new transaction for the given store using the given model.
    * @param client The gRPC client to use for the transaction.
-   * @param dbID the ID of the database
+   * @param threadID the ID of the database
    * @param modelName The human-readable name for the model.
    */
   constructor(
     protected readonly client: grpc.Client<TRequest, TResponse>,
-    protected readonly dbID: ThreadID,
+    protected readonly threadID: ThreadID,
     protected readonly modelName: string,
   ) {}
 

--- a/packages/client/src/models/WriteTransaction.ts
+++ b/packages/client/src/models/WriteTransaction.ts
@@ -26,17 +26,17 @@ export class WriteTransaction extends Transaction<WriteTransactionRequest, Write
   constructor(
     protected readonly context: ContextInterface,
     protected readonly client: grpc.Client<WriteTransactionRequest, WriteTransactionReply>,
-    protected readonly dbID: ThreadID,
+    protected readonly threadID: ThreadID,
     protected readonly modelName: string,
   ) {
-    super(client, dbID, modelName)
+    super(client, threadID, modelName)
   }
   /**
    * start begins the transaction. All operations between start and end will be applied as a single transaction upon a call to end.
    */
   public async start() {
     const startReq = new StartTransactionRequest()
-    startReq.setDbid(this.dbID.toBytes())
+    startReq.setDbid(this.threadID.toBytes())
     startReq.setCollectionname(this.modelName)
     const req = new WriteTransactionRequest()
     req.setStarttransactionrequest(startReq)


### PR DESCRIPTION
a simple one. that old `dbID` was confusing me as a user. everywhere else it's just a `threadID`. consoldiated on the same term.