### PR TITLE
fix(client): thread-name header is un-set if done at newDb time

### DIFF
--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -163,6 +163,7 @@ export class Client {
     if (name !== undefined) req.setName(name)
     await this.unary(API.NewDB, req)
     this.context.withThread(dbID.toString())
+    if (name !== undefined) this.context.withThreadName(name)
     return dbID
   }
 


### PR DESCRIPTION
fixes https://github.com/textileio/js-threads/commit/81970e0d523498b85c4af5e551684776f0097109#r39680150