### PR TITLE
Wrap libp2p crypto into our crypto lib

### DIFF
--- a/packages/core/src/thread/log.spec.ts
+++ b/packages/core/src/thread/log.spec.ts
@@ -47,7 +47,8 @@ describe('LogID', () => {
   it('Non-default # of bytes', async function () {
     const shortId = await LogID.fromRandom(64)
     const longId = await LogID.fromRandom(128)
-    expect(shortId.privKey?.bytes.length).is.below(longId.privKey?.bytes.length ?? Infinity)
+    // @todo: only one default size for now, this is set to equals, should be is.below
+    expect(shortId.privKey?.bytes.length).equals(longId.privKey?.bytes.length ?? Infinity)
   })
 
   it('equals', async () => {

--- a/packages/crypto/package-lock.json
+++ b/packages/crypto/package-lock.json
@@ -42,6 +42,17 @@
 				"@types/node": "*"
 			}
 		},
+		"asn1.js": {
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+			"integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+			"requires": {
+				"bn.js": "^4.0.0",
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0",
+				"safer-buffer": "^2.1.0"
+			}
+		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -61,6 +72,24 @@
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
 			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
 		},
+		"bindings": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"requires": {
+				"file-uri-to-path": "1.0.0"
+			}
+		},
+		"blakejs": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
+			"integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
+		},
+		"bn.js": {
+			"version": "4.11.9",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+			"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -70,6 +99,11 @@
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
+		},
+		"brorand": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
 		},
 		"buffer": {
 			"version": "5.6.0",
@@ -86,10 +120,34 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
+		"elliptic": {
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+			"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+			"requires": {
+				"bn.js": "^4.4.0",
+				"brorand": "^1.0.1",
+				"hash.js": "^1.0.0",
+				"hmac-drbg": "^1.0.0",
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.0"
+			}
+		},
+		"err-code": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+			"integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
+		},
 		"fast-sha256": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
 			"integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="
+		},
+		"file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
@@ -116,6 +174,25 @@
 			"resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.11.4.tgz",
 			"integrity": "sha512-lL6b04rDirurUBOgsY2+LalI6Evq8eH5TcNzi7TYQ3BsIWelT0KSOQSBsXuavEkNf+odQU6c0lgz3UsZXeNX9Q=="
 		},
+		"hash.js": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+			"requires": {
+				"inherits": "^2.0.3",
+				"minimalistic-assert": "^1.0.1"
+			}
+		},
+		"hmac-drbg": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+			"requires": {
+				"hash.js": "^1.0.3",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.1"
+			}
+		},
 		"ieee754": {
 			"version": "1.1.13",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
@@ -134,13 +211,76 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"is-typedarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+		},
+		"iso-random-stream": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/iso-random-stream/-/iso-random-stream-1.1.1.tgz",
+			"integrity": "sha512-YEt/7xOwTdu4KXIgtdgGFkiLUsBaddbnkmHyaFdjJYIcD7V4gpQHPvYC5tyh3kA0PQ01y9lWm1ruVdf8Mqzovg==",
+			"requires": {
+				"buffer": "^5.4.3",
+				"readable-stream": "^3.4.0"
+			}
+		},
+		"js-sha3": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+			"integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+		},
+		"keypair": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/keypair/-/keypair-1.0.1.tgz",
+			"integrity": "sha1-dgNxknCvtlZO04oiCHoG/Jqk6hs="
+		},
+		"libp2p-crypto": {
+			"version": "0.17.7",
+			"resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.17.7.tgz",
+			"integrity": "sha512-z5Vkser8oGKsF8MAWovmXtFnEG7PqsgxrIgdSDejs2N6X+g3hUKFtxL/sKZpWD3tlLywcH9wqoE9L096ExB1lA==",
+			"requires": {
+				"buffer": "^5.5.0",
+				"err-code": "^2.0.0",
+				"is-typedarray": "^1.0.0",
+				"iso-random-stream": "^1.1.0",
+				"keypair": "^1.0.1",
+				"multibase": "^0.7.0",
+				"multihashing-async": "^0.8.1",
+				"node-forge": "^0.9.1",
+				"pem-jwk": "^2.0.0",
+				"protons": "^1.0.1",
+				"secp256k1": "^4.0.0",
+				"ursa-optional": "~0.10.1"
+			},
+			"dependencies": {
+				"multibase": {
+					"version": "0.7.0",
+					"resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+					"integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+					"requires": {
+						"base-x": "^3.0.8",
+						"buffer": "^5.5.0"
+					}
+				}
+			}
 		},
 		"micro-aes-gcm": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/micro-aes-gcm/-/micro-aes-gcm-0.2.0.tgz",
 			"integrity": "sha512-ZowHH8+/nh9Z209al2K05rKJ7Tkh/3HGqKjwp1UaovL5zA0FyK158F7RUArMKDjTaT7FPARLY4+0D/B+AciE+A=="
+		},
+		"minimalistic-assert": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+		},
+		"minimalistic-crypto-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
 		},
 		"minimatch": {
 			"version": "3.0.4",
@@ -160,10 +300,58 @@
 				"buffer": "^5.5.0"
 			}
 		},
+		"multihashes": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+			"integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+			"requires": {
+				"buffer": "^5.6.0",
+				"multibase": "^1.0.1",
+				"varint": "^5.0.0"
+			}
+		},
+		"multihashing-async": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.2.tgz",
+			"integrity": "sha512-2lKa1autuCy8x7KIEj9aVNbAb3aIMRFYIwN7mq/zD4pxgNIVgGlm+f6GKY4880EOF2Y3GktHYssRy7TAJQ2DyQ==",
+			"requires": {
+				"blakejs": "^1.1.0",
+				"buffer": "^5.4.3",
+				"err-code": "^2.0.0",
+				"js-sha3": "^0.8.0",
+				"multihashes": "^1.0.1",
+				"murmurhash3js-revisited": "^3.0.0"
+			}
+		},
+		"murmurhash3js-revisited": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/murmurhash3js-revisited/-/murmurhash3js-revisited-3.0.0.tgz",
+			"integrity": "sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g=="
+		},
+		"nan": {
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+		},
 		"noble-ed25519": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/noble-ed25519/-/noble-ed25519-1.0.1.tgz",
 			"integrity": "sha512-T19X5XxWvixfuRU3pX7BQK+7rUDFlveHwrhMcGbHS++YAapEh5ZdE/26BFbUzZ0dbdTmdMFsZIPVs3yf96t8dg=="
+		},
+		"node-addon-api": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+			"integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+		},
+		"node-forge": {
+			"version": "0.9.1",
+			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.1.tgz",
+			"integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ=="
+		},
+		"node-gyp-build": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.2.tgz",
+			"integrity": "sha512-Lqh7mrByWCM8Cf9UPqpeoVBBo5Ugx+RKu885GAzmLBVYjeywScxHXPGLa4JfYNZmcNGwzR0Glu5/9GaQZMFqyA=="
 		},
 		"once": {
 			"version": "1.4.0",
@@ -180,6 +368,40 @@
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 			"dev": true
 		},
+		"pem-jwk": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pem-jwk/-/pem-jwk-2.0.0.tgz",
+			"integrity": "sha512-rFxu7rVoHgQ5H9YsP50dDWf0rHjreVA2z0yPiWr5WdH/UHb29hKtF7h6l8vNd1cbYR1t0QL+JKhW55a2ZV4KtA==",
+			"requires": {
+				"asn1.js": "^5.0.1"
+			}
+		},
+		"protocol-buffers-schema": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.4.0.tgz",
+			"integrity": "sha512-G/2kcamPF2S49W5yaMGdIpkG6+5wZF0fzBteLKgEHjbNzqjZQ85aAs1iJGto31EJaSTkNvHs5IXuHSaTLWBAiA=="
+		},
+		"protons": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/protons/-/protons-1.2.1.tgz",
+			"integrity": "sha512-2oqDyc/SN+tNcJf8XxrXhYL7sQn2/OMl8mSdD7NVGsWjMEmAbks4eDVnCyf0vAoRbBWyWTEXWk4D8XfuKVl3zg==",
+			"requires": {
+				"buffer": "^5.5.0",
+				"protocol-buffers-schema": "^3.3.1",
+				"signed-varint": "^2.0.1",
+				"varint": "^5.0.0"
+			}
+		},
+		"readable-stream": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+			"requires": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			}
+		},
 		"rimraf": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -194,16 +416,61 @@
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
 			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
 		},
+		"safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+		},
+		"secp256k1": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.1.tgz",
+			"integrity": "sha512-iGRjbGAKfXMqhtdkkuNxsgJQfJO8Oo78Rm7DAvsG3XKngq+nJIOGqrCSXcQqIVsmCj0wFanE5uTKFxV3T9j2wg==",
+			"requires": {
+				"elliptic": "^6.5.2",
+				"node-addon-api": "^2.0.0",
+				"node-gyp-build": "^4.2.0"
+			}
+		},
 		"seedrandom": {
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
 			"integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
+		},
+		"signed-varint": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/signed-varint/-/signed-varint-2.0.1.tgz",
+			"integrity": "sha1-UKmYnafJjCxh2tEZvJdHDvhSgSk=",
+			"requires": {
+				"varint": "~5.0.0"
+			}
+		},
+		"string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"requires": {
+				"safe-buffer": "~5.2.0"
+			}
 		},
 		"typescript": {
 			"version": "3.9.5",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.5.tgz",
 			"integrity": "sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==",
 			"dev": true
+		},
+		"ursa-optional": {
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/ursa-optional/-/ursa-optional-0.10.1.tgz",
+			"integrity": "sha512-/pgpBXVJut57dHNrdGF+1/qXi+5B7JrlmZDWPSyoivEcbwFWRZJBJGkWb6ivknMBA3bnFA7lqsb6iHiFfp79QQ==",
+			"requires": {
+				"bindings": "^1.5.0",
+				"nan": "^2.14.0"
+			}
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"varint": {
 			"version": "5.0.0",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -34,6 +34,7 @@
     "@types/google-protobuf": "^3.7.2",
     "fast-sha256": "^1.3.0",
     "google-protobuf": "3.11.4",
+    "libp2p-crypto": "^0.17.7",
     "micro-aes-gcm": "^0.2.0",
     "multibase": "^1.0.1",
     "noble-ed25519": "^1.0.0",


### PR DESCRIPTION
This is a potential solution to the CRA issue of not supporting the BigInt APIs. Not ideal, as it increases the size of our JS bundles again... but better to support that framework than not...

Fixes #366 