### PR TITLE
feat(devmode): enable keys non requiring signing

### DIFF
--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -266,6 +266,8 @@ export class Context implements ContextInterface {
 
   async withKeyInfo(key?: KeyInfo, date?: Date) {
     if (key === undefined) return this
+    // Enables the use of insecure / non-signing keys
+    if (key.secret === '') return this.withAPIKey(key.key)
     const sig = await createAPISig(key.secret, date)
     return this.withAPIKey(key.key).withAPISig(sig)
   }

--- a/packages/security/src/index.ts
+++ b/packages/security/src/index.ts
@@ -40,7 +40,6 @@ export type UserAuth = {
  * ```
  * @param {string} key - API key. Can be embedded/shared within an app.
  * @param {string} secret - User group/account secret. Should not be embedded/shared publicly.
- * @param {number} type - Key type. 0 of ACCOUNT or 1 of USER
  */
 export type KeyInfo = {
   /**
@@ -51,10 +50,6 @@ export type KeyInfo = {
    * User group/account secret. Should not be embedded/shared publicly.
    */
   secret: string
-  /**
-   * Key type. Zero of ACCOUNT or One of USER
-   */
-  type: 0 | 1
 }
 
 /**


### PR DESCRIPTION
went to do a round of onboarding improvements in docs and realized this was still missing. just tested it out and using the non-signing keys requires a context method that doesn't try to sign with the secret. this was a pretty simple way to enable it without having a new type or a new api. simply set the secret to an empty string and use the withKeyInfo method anywhere it's available.

also i noticed that KeyInfo.type isn't used anywhere so got rid of it, but I could be mistaken. 