### PR TITLE
fix: don't error on listen for deletes fixes #141

### DIFF
--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -741,14 +741,18 @@ export class Client {
       req.addFilters(requestFilter)
     }
 
+    const decoder = new TextDecoder()
+
     const client = grpc.client<pb.ListenRequest, pb.ListenReply, APIListen>(API.Listen, {
       host: this.serviceHost,
       transport: this.rpcOptions.transport,
       debug: this.rpcOptions.debug,
     })
     client.onMessage((message: pb.ListenReply) => {
-      const ret: Instance<T> = {
-        instance: JSON.parse(Buffer.from(message.getInstance_asU8()).toString()),
+      const str = decoder.decode(message.getInstance_asU8())
+      let ret: Instance<T> | undefined
+      if (str !== '') {
+        ret = { instance: JSON.parse(str) }
       }
       nextTick(() => callback(ret))
     })


### PR DESCRIPTION
Signed-off-by: Carson Farmer <carson.farmer@gmail.com>

## Description

This checks returned instances _before_ parsing JSON. Also adds a regression test to ensure we don't end up doing this again in the future.

Fixes #141 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

All exists tests continue to pass, and a new regression test was added.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
