### PR TITLE
Moves most types to deps + min cleanup

### DIFF
--- a/packages/client/package-lock.json
+++ b/packages/client/package-lock.json
@@ -30,35 +30,25 @@
 		"@types/json-schema": {
 			"version": "7.0.5",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
-			"integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
-			"dev": true
+			"integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ=="
 		},
 		"@types/multibase": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/@types/multibase/-/multibase-0.6.0.tgz",
 			"integrity": "sha512-PhQiA4pCcIG5yibX/G7K7mk/CXw0HTY98R+efcbbfce9WOyAGbIVqY3zv5kMm+vMAunY29aeOtQ96ePjeX417w==",
-			"dev": true,
 			"requires": {
 				"@types/node": "*"
 			}
 		},
-		"@types/next-tick": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@types/next-tick/-/next-tick-1.0.0.tgz",
-			"integrity": "sha512-J9zljHWKO5EpdiJG9WHLE8Op6Zr34bTfeVw1hhRIRc9GHUVNKT0HdRUFAXOntT/ttl4BP9BJU2keR0C3pZXFdQ==",
-			"dev": true
-		},
 		"@types/node": {
 			"version": "14.0.13",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.13.tgz",
-			"integrity": "sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA==",
-			"dev": true
+			"integrity": "sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA=="
 		},
 		"@types/to-json-schema": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/@types/to-json-schema/-/to-json-schema-0.2.0.tgz",
 			"integrity": "sha512-9fqRjNFSSxJ8dQrE4v8gThS5ftxdFj8Q0y8hAjaF+uN+saJRxLiJdtFaDd9sv3bhzwcB2oDJpT/1ZelHnexbLw==",
-			"dev": true,
 			"requires": {
 				"@types/json-schema": "*"
 			}
@@ -243,11 +233,6 @@
 				"buffer": "^5.6.0",
 				"varint": "^5.0.0"
 			}
-		},
-		"next-tick": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-			"integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
 		},
 		"once": {
 			"version": "1.4.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -52,13 +52,11 @@
     "@types/google-protobuf": "^3.7.2",
     "cids": "^0.8.0",
     "google-protobuf": "^3.10.0",
-    "next-tick": "^1.1.0",
-    "to-json-schema": "^0.2.5"
+    "to-json-schema": "^0.2.5",
+    "@types/multibase": "^0.6.0",
+    "@types/to-json-schema": "^0.2.0"
   },
   "devDependencies": {
-    "@types/multibase": "^0.6.0",
-    "@types/next-tick": "^1.0.0",
-    "@types/to-json-schema": "^0.2.0",
     "rimraf": "^3.0.0",
     "typescript": "^3.7.2"
   },

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -5,7 +5,6 @@
 import { grpc } from '@improbable-eng/grpc-web'
 import { API, APIGetToken, APIListen } from '@textile/threads-client-grpc/threads_pb_service'
 import * as pb from '@textile/threads-client-grpc/threads_pb'
-import nextTick from 'next-tick'
 import { Identity, Libp2pCryptoIdentity, ThreadKey } from '@textile/threads-core'
 import { Multiaddr } from '@textile/multiaddr'
 import { ThreadID } from '@textile/threads-id'
@@ -756,14 +755,14 @@ export class Client {
       if (str !== '') {
         ret = { instance: JSON.parse(str) }
       }
-      nextTick(() => callback(ret))
+      callback(ret)
     })
 
     client.onEnd((status: grpc.Code, message: string, _trailers: grpc.Metadata) => {
       if (status !== grpc.Code.OK) {
-        nextTick(() => callback(undefined, new Error(message)))
+        callback(undefined, new Error(message))
       }
-      nextTick(callback)
+      callback()
     })
 
     this.context.toMetadata().then((metadata) => {

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -149,7 +149,6 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@types/multiaddr/-/multiaddr-7.2.0.tgz",
 			"integrity": "sha512-4oWyVIQjiOGIs0iApwtLSetRRBFGo2rnPQwclQFpHz6Zm0EHwyQbMcboLVJH19T8EdWKnEJ+Y62LrZ/ZNBBjbw==",
-			"dev": true,
 			"requires": {
 				"@types/node": "*"
 			}
@@ -171,7 +170,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/@types/varint/-/varint-5.0.0.tgz",
 			"integrity": "sha512-dIJiYqeDnYQ5Bc4mv+E5prqFIQlUTM1yDzwC5VQfL29pcYlm/5q1shY/MjbBT1FQAU5gzKE10DdGbu8B2EoFQg==",
-			"dev": true,
 			"requires": {
 				"@types/node": "*"
 			}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,14 +32,14 @@
     }
   ],
   "devDependencies": {
-    "@types/multiaddr": "^7.2.0",
-    "@types/node": "^14.0.5",
-    "@types/varint": "^5.0.0",
     "cids": "^0.8.0",
     "rimraf": "^3.0.0",
     "typescript": "^3.7.2"
   },
   "dependencies": {
+    "@types/multiaddr": "^7.2.0",
+    "@types/node": "^14.0.5",
+    "@types/varint": "^5.0.0",
     "@ipld/block": "^4.0.0",
     "@textile/multiaddr": "^0.0.21",
     "@textile/threads-crypto": "^0.1.1",

--- a/packages/crypto/package-lock.json
+++ b/packages/crypto/package-lock.json
@@ -22,7 +22,6 @@
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/@types/multibase/-/multibase-0.6.0.tgz",
 			"integrity": "sha512-PhQiA4pCcIG5yibX/G7K7mk/CXw0HTY98R+efcbbfce9WOyAGbIVqY3zv5kMm+vMAunY29aeOtQ96ePjeX417w==",
-			"dev": true,
 			"requires": {
 				"@types/node": "*"
 			}
@@ -30,14 +29,12 @@
 		"@types/node": {
 			"version": "14.0.13",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.13.tgz",
-			"integrity": "sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA==",
-			"dev": true
+			"integrity": "sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA=="
 		},
 		"@types/varint": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/@types/varint/-/varint-5.0.0.tgz",
 			"integrity": "sha512-dIJiYqeDnYQ5Bc4mv+E5prqFIQlUTM1yDzwC5VQfL29pcYlm/5q1shY/MjbBT1FQAU5gzKE10DdGbu8B2EoFQg==",
-			"dev": true,
 			"requires": {
 				"@types/node": "*"
 			}

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -21,12 +21,12 @@
   "license": "MIT",
   "repository": "github:textileio/js-threads",
   "devDependencies": {
-    "@types/multibase": "^0.6.0",
-    "@types/varint": "^5.0.0",
     "rimraf": "^3.0.0",
     "typescript": "^3.7.2"
   },
   "dependencies": {
+    "@types/multibase": "^0.6.0",
+    "@types/varint": "^5.0.0",
     "@consento/sync-randombytes": "^1.0.5",
     "@types/google-protobuf": "^3.7.2",
     "fast-sha256": "^1.3.0",

--- a/packages/database/package-lock.json
+++ b/packages/database/package-lock.json
@@ -52,14 +52,12 @@
 		"@types/abstract-leveldown": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/@types/abstract-leveldown/-/abstract-leveldown-5.0.1.tgz",
-			"integrity": "sha512-wYxU3kp5zItbxKmeRYCEplS2MW7DzyBnxPGj+GJVHZEUZiK/nn5Ei1sUFgURDh+X051+zsGe28iud3oHjrYWQQ==",
-			"dev": true
+			"integrity": "sha512-wYxU3kp5zItbxKmeRYCEplS2MW7DzyBnxPGj+GJVHZEUZiK/nn5Ei1sUFgURDh+X051+zsGe28iud3oHjrYWQQ=="
 		},
 		"@types/async-retry": {
 			"version": "1.4.2",
 			"resolved": "https://registry.npmjs.org/@types/async-retry/-/async-retry-1.4.2.tgz",
 			"integrity": "sha512-GUDuJURF0YiJZ+CBjNQA0+vbP/VHlJbB0sFqkzsV7EcOPRfurVonXpXKAt3w8qIjM1TEzpz6hc6POocPvHOS3w==",
-			"dev": true,
 			"requires": {
 				"@types/retry": "*"
 			}
@@ -74,7 +72,6 @@
 			"version": "0.7.1",
 			"resolved": "https://registry.npmjs.org/@types/datastore-core/-/datastore-core-0.7.1.tgz",
 			"integrity": "sha512-ZYMfcxTIo/fDa52c1taPRQ7iUcaFGjOPsN1nV2AP0tNpFXwLBEYUzG+nlIqOxVonXXNG3jrw+loBOVHOoS0tdw==",
-			"dev": true,
 			"requires": {
 				"@types/interface-datastore": "*"
 			}
@@ -83,7 +80,6 @@
 			"version": "0.14.0",
 			"resolved": "https://registry.npmjs.org/@types/datastore-level/-/datastore-level-0.14.0.tgz",
 			"integrity": "sha512-Os1zeTCtX17+vN0/JpJmKp8Hoj0StYtcJI2CWLW+u/HRSHlulQrU1viCxm5urg0DqhZQpy6PNCAcAh5+BFGyyA==",
-			"dev": true,
 			"requires": {
 				"@types/abstract-leveldown": "*",
 				"@types/interface-datastore": "*",
@@ -95,7 +91,6 @@
 			"version": "0.8.0",
 			"resolved": "https://registry.npmjs.org/@types/interface-datastore/-/interface-datastore-0.8.0.tgz",
 			"integrity": "sha512-apbO3UBpzuqIB/QjvClc7tXOH3m2HYWhYqSBS3dycLrULIqk6dNVUkkI7WI3hXXUEW6YcQAkj6IDMm4A2ERhTg==",
-			"dev": true,
 			"requires": {
 				"@types/node": "*"
 			}
@@ -103,14 +98,12 @@
 		"@types/json-schema": {
 			"version": "7.0.5",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
-			"integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
-			"dev": true
+			"integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ=="
 		},
 		"@types/levelup": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/@types/levelup/-/levelup-4.3.0.tgz",
 			"integrity": "sha512-h82BoajhjU/zwLoM4BUBX/SCodCFi1ae/ZlFOYh5Z4GbHeaXj9H709fF1LYl/StrK8KSwnJOeMRPo9lnC6sz4w==",
-			"dev": true,
 			"requires": {
 				"@types/abstract-leveldown": "*",
 				"@types/node": "*"
@@ -124,8 +117,7 @@
 		"@types/retry": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-			"dev": true
+			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
 		},
 		"@types/sinon": {
 			"version": "9.0.4",
@@ -146,7 +138,6 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/@types/to-json-schema/-/to-json-schema-0.2.0.tgz",
 			"integrity": "sha512-9fqRjNFSSxJ8dQrE4v8gThS5ftxdFj8Q0y8hAjaF+uN+saJRxLiJdtFaDd9sv3bhzwcB2oDJpT/1ZelHnexbLw==",
-			"dev": true,
 			"requires": {
 				"@types/json-schema": "*"
 			}
@@ -154,8 +145,7 @@
 		"@types/url-parse": {
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/@types/url-parse/-/url-parse-1.4.3.tgz",
-			"integrity": "sha512-4kHAkbV/OfW2kb5BLVUuUMoumB3CP8rHqlw48aHvFy5tf9ER0AfOonBlX29l/DD68G70DmyhRlSYfQPSYpC5Vw==",
-			"dev": true
+			"integrity": "sha512-4kHAkbV/OfW2kb5BLVUuUMoumB3CP8rHqlw48aHvFy5tf9ER0AfOonBlX29l/DD68G70DmyhRlSYfQPSYpC5Vw=="
 		},
 		"abort-controller": {
 			"version": "3.0.0",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -67,18 +67,18 @@
     "to-json-schema": "^0.2.3",
     "tsee": "^1.3.0",
     "ulid": "^2.3.0",
-    "url-parse": "^1.4.7"
-  },
-  "devDependencies": {
+    "url-parse": "^1.4.7",
+    "@types/to-json-schema": "^0.2.0",
+    "@types/url-parse": "^1.4.3",
     "@types/async-retry": "^1.4.1",
-    "@types/browser-or-node": "^1.2.0",
     "@types/datastore-core": "^0.7.0",
     "@types/datastore-level": "^0.14.0",
     "@types/interface-datastore": "^0.8.0",
-    "@types/json-schema": "^7.0.4",
+    "@types/json-schema": "^7.0.4"
+  },
+  "devDependencies": {
     "@types/sinon": "^9.0.0",
-    "@types/to-json-schema": "^0.2.0",
-    "@types/url-parse": "^1.4.3",
+    "@types/browser-or-node": "^1.2.0",
     "browser-or-node": "^1.2.1",
     "delay": "^4.3.0",
     "level": "^6.0.1",

--- a/packages/id/package-lock.json
+++ b/packages/id/package-lock.json
@@ -17,7 +17,6 @@
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/@types/multibase/-/multibase-0.6.0.tgz",
 			"integrity": "sha512-PhQiA4pCcIG5yibX/G7K7mk/CXw0HTY98R+efcbbfce9WOyAGbIVqY3zv5kMm+vMAunY29aeOtQ96ePjeX417w==",
-			"dev": true,
 			"requires": {
 				"@types/node": "*"
 			}
@@ -25,14 +24,12 @@
 		"@types/node": {
 			"version": "14.0.4",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.4.tgz",
-			"integrity": "sha512-k3NqigXWRzQZVBDS5D1U70A5E8Qk4Kh+Ha/x4M8Bt9pF0X05eggfnC9+63Usc9Q928hRUIpIhTQaXsZwZBl4Ew==",
-			"dev": true
+			"integrity": "sha512-k3NqigXWRzQZVBDS5D1U70A5E8Qk4Kh+Ha/x4M8Bt9pF0X05eggfnC9+63Usc9Q928hRUIpIhTQaXsZwZBl4Ew=="
 		},
 		"@types/varint": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/@types/varint/-/varint-5.0.0.tgz",
 			"integrity": "sha512-dIJiYqeDnYQ5Bc4mv+E5prqFIQlUTM1yDzwC5VQfL29pcYlm/5q1shY/MjbBT1FQAU5gzKE10DdGbu8B2EoFQg==",
-			"dev": true,
 			"requires": {
 				"@types/node": "*"
 			}

--- a/packages/id/package.json
+++ b/packages/id/package.json
@@ -21,12 +21,12 @@
   },
   "repository": "github:textileio/js-threads",
   "devDependencies": {
-    "@types/multibase": "^0.6.0",
-    "@types/varint": "^5.0.0",
     "rimraf": "^3.0.0",
     "typescript": "^3.7.2"
   },
   "dependencies": {
+    "@types/multibase": "^0.6.0",
+    "@types/varint": "^5.0.0",
     "@consento/sync-randombytes": "^1.0.4",
     "multibase": "^1.0.1",
     "varint": "^5.0.0"

--- a/packages/multiaddr/package-lock.json
+++ b/packages/multiaddr/package-lock.json
@@ -8,7 +8,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/@types/bs58/-/bs58-4.0.1.tgz",
 			"integrity": "sha512-yfAgiWgVLjFCmRv8zAcOIHywYATEwiTVccTLnRp6UxTNavT55M9d/uhK3T03St/+8/z/wW+CRjGKUNmEqoHHCA==",
-			"dev": true,
 			"requires": {
 				"base-x": "^3.0.6"
 			}
@@ -17,7 +16,6 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@types/multiaddr/-/multiaddr-7.2.0.tgz",
 			"integrity": "sha512-4oWyVIQjiOGIs0iApwtLSetRRBFGo2rnPQwclQFpHz6Zm0EHwyQbMcboLVJH19T8EdWKnEJ+Y62LrZ/ZNBBjbw==",
-			"dev": true,
 			"requires": {
 				"@types/node": "*"
 			}
@@ -39,7 +37,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/@types/varint/-/varint-5.0.0.tgz",
 			"integrity": "sha512-dIJiYqeDnYQ5Bc4mv+E5prqFIQlUTM1yDzwC5VQfL29pcYlm/5q1shY/MjbBT1FQAU5gzKE10DdGbu8B2EoFQg==",
-			"dev": true,
 			"requires": {
 				"@types/node": "*"
 			}

--- a/packages/multiaddr/package.json
+++ b/packages/multiaddr/package.json
@@ -25,13 +25,13 @@
     }
   ],
   "devDependencies": {
-    "@types/bs58": "^4.0.1",
-    "@types/multiaddr": "^7.2.0",
-    "@types/varint": "^5.0.0",
     "rimraf": "^3.0.0",
     "typescript": "^3.7.2"
   },
   "dependencies": {
+    "@types/bs58": "^4.0.1",
+    "@types/multiaddr": "^7.2.0",
+    "@types/varint": "^5.0.0",
     "@textile/threads-id": "^0.1.10",
     "@types/multibase": "^0.6.0",
     "bs58": "^4.0.1",

--- a/packages/network-client/package-lock.json
+++ b/packages/network-client/package-lock.json
@@ -30,8 +30,7 @@
 		"@types/node": {
 			"version": "14.0.13",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.13.tgz",
-			"integrity": "sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA==",
-			"dev": true
+			"integrity": "sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA=="
 		},
 		"balanced-match": {
 			"version": "1.0.0",

--- a/packages/network-client/package.json
+++ b/packages/network-client/package.json
@@ -21,6 +21,7 @@
   },
   "repository": "github:textileio/js-threads",
   "dependencies": {
+    "@types/node": "^14.0.1",
     "@improbable-eng/grpc-web": "^0.12.0",
     "@textile/context": "^0.6.1",
     "@textile/grpc-transport": "^0.0.0",
@@ -49,7 +50,6 @@
     }
   ],
   "devDependencies": {
-    "@types/node": "^14.0.1",
     "rimraf": "^3.0.0",
     "typescript": "^3.7.2"
   },

--- a/packages/network/package-lock.json
+++ b/packages/network/package-lock.json
@@ -8,7 +8,6 @@
 			"version": "0.7.1",
 			"resolved": "https://registry.npmjs.org/@types/datastore-core/-/datastore-core-0.7.1.tgz",
 			"integrity": "sha512-ZYMfcxTIo/fDa52c1taPRQ7iUcaFGjOPsN1nV2AP0tNpFXwLBEYUzG+nlIqOxVonXXNG3jrw+loBOVHOoS0tdw==",
-			"dev": true,
 			"requires": {
 				"@types/interface-datastore": "*"
 			}
@@ -17,16 +16,9 @@
 			"version": "0.8.0",
 			"resolved": "https://registry.npmjs.org/@types/interface-datastore/-/interface-datastore-0.8.0.tgz",
 			"integrity": "sha512-apbO3UBpzuqIB/QjvClc7tXOH3m2HYWhYqSBS3dycLrULIqk6dNVUkkI7WI3hXXUEW6YcQAkj6IDMm4A2ERhTg==",
-			"dev": true,
 			"requires": {
 				"@types/node": "*"
 			}
-		},
-		"@types/next-tick": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@types/next-tick/-/next-tick-1.0.0.tgz",
-			"integrity": "sha512-J9zljHWKO5EpdiJG9WHLE8Op6Zr34bTfeVw1hhRIRc9GHUVNKT0HdRUFAXOntT/ttl4BP9BJU2keR0C3pZXFdQ==",
-			"dev": true
 		},
 		"@types/node": {
 			"version": "14.0.13",
@@ -446,12 +438,6 @@
 			"version": "3.1.10",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.10.tgz",
 			"integrity": "sha512-iZFMXKeXWkxzlfmMfM91gw7YhN2sdJtixY+eZh9V6QWJWTOiurhpKhBMgr82pfzgSqglQgqYSCowEYsz8D++6w=="
-		},
-		"next-tick": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-			"integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
-			"dev": true
 		},
 		"node-fetch": {
 			"version": "2.6.0",

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -21,6 +21,8 @@
   },
   "repository": "github:textileio/js-threads",
   "dependencies": {
+    "@types/datastore-core": "^0.7.0",
+    "@types/interface-datastore": "^0.8.0",
     "@textile/context": "^0.6.1",
     "@textile/threads-core": "^0.1.30",
     "@textile/threads-crypto": "^0.1.1",
@@ -50,10 +52,6 @@
     }
   ],
   "devDependencies": {
-    "@types/datastore-core": "^0.7.0",
-    "@types/interface-datastore": "^0.8.0",
-    "@types/next-tick": "^1.0.0",
-    "next-tick": "^1.1.0",
     "rimraf": "^3.0.0",
     "typescript": "^3.7.2"
   },

--- a/packages/store/package-lock.json
+++ b/packages/store/package-lock.json
@@ -8,7 +8,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@types/datastore-core/-/datastore-core-0.7.0.tgz",
       "integrity": "sha512-22O6TJUteMJRA2hUJrAUecTdN0pft2tzjDSgQEU3iLQhcY/SdBOoDt5DIj48hj3e4FtWlG8AAuUwAm9EB5jMCA==",
-      "dev": true,
       "requires": {
         "@types/interface-datastore": "*"
       }
@@ -17,7 +16,6 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@types/interface-datastore/-/interface-datastore-0.8.0.tgz",
       "integrity": "sha512-apbO3UBpzuqIB/QjvClc7tXOH3m2HYWhYqSBS3dycLrULIqk6dNVUkkI7WI3hXXUEW6YcQAkj6IDMm4A2ERhTg==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -22,6 +22,8 @@
   "repository": "github:textileio/js-threads",
   "dependencies": {
     "@types/lexicographic-integer": "^1.1.0",
+    "@types/datastore-core": "^0.7.0",
+    "@types/interface-datastore": "^0.8.0",
     "async-rwlock": "^1.1.1",
     "cbor-sync": "^1.0.4",
     "datastore-core": "^1.0.0",
@@ -33,8 +35,6 @@
     "ulid": "^2.3.0"
   },
   "devDependencies": {
-    "@types/datastore-core": "^0.7.0",
-    "@types/interface-datastore": "^0.8.0",
     "rimraf": "^3.0.0",
     "streaming-iterables": "^5.0.2",
     "typescript": "^3.7.2"


### PR DESCRIPTION
Signed-off-by: Carson Farmer <carson.farmer@gmail.com>

## Description

This PR moves all @types definition files from devDependencies to dependencies where appropriate. These types were erroneously left in devDependencies, which works fine for Textile's purposes, but once these projects are being used in external Typescript projects, this results in missing types errors.

Fixes #397 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

These changes should not affect any internal tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
