### PR TITLE
Supports auto-semantic version releases

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "@commitlint/config-conventional"
-  ]
-}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,60 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+        with:
+          # pulls all commits (needed for lerna to correctly version)
+          fetch-depth: "0"
+        # pulls all tags (needed for lerna to correctly version)
+      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+
+      - name: Cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Setup
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+
+      - name: Install
+        run: npm install
+
+      - name: Bootstrap
+        run: npx lerna bootstrap
+
+      - name: Publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+        run: npx lerna publish --yes
+  docs:
+    needs: publish
+    name: Docs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Docs
+        run: npm run docs
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v2
+        env:
+          ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          PUBLISH_BRANCH: gh-pages
+          PUBLISH_DIR: docs

--- a/lerna.json
+++ b/lerna.json
@@ -1,11 +1,12 @@
 {
-  "packages": [
-    "packages/*"
-  ],
+  "packages": ["packages/*"],
   "version": "independent",
   "command": {
     "version": {
       "message": "chore: release/publish"
+    },
+    "publish": {
+      "conventionalCommits": true
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11261,9 +11261,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.6.tgz",
-      "integrity": "sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==",
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
       "dev": true
     },
     "typescript-docs-verifier": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "publish": "lerna publish",
     "compile": "lerna run compile",
     "build": "lerna run build --stream",
+    "commitmsg": "commitlint -e $GIT_PARAMS",
     "lint": "eslint --fix --ext .js,.ts packages/*/src/**/*",
     "lint:check": "eslint --ext .js,.ts packages/*/src/**/*",
     "test": "npm run test:node && npm run test:browser && npm run test:docs",
@@ -63,6 +64,11 @@
     "ws": "^7.2.3",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.12"
+  },
+  "commitlint": {
+    "extends": [
+      "@commitlint/config-conventional"
+    ]
   },
   "husky": {
     "hooks": {

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [0.8.3](https://github.com/textileio/js-threads/compare/@textile/threads-client@0.8.2...@textile/threads-client@0.8.3) (2020-07-16)
+
+**Note:** Version bump only for package @textile/threads-client

--- a/packages/client/package-lock.json
+++ b/packages/client/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@textile/threads-client",
-	"version": "0.8.2",
+	"version": "0.8.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/context/CHANGELOG.md
+++ b/packages/context/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [0.6.3](https://github.com/textileio/js-threads/compare/@textile/context@0.6.2...@textile/context@0.6.3) (2020-07-16)
+
+**Note:** Version bump only for package @textile/context

--- a/packages/context/package-lock.json
+++ b/packages/context/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@textile/context",
-	"version": "0.6.2",
+	"version": "0.6.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [0.1.32](https://github.com/textileio/js-threads/compare/@textile/threads-core@0.1.31...@textile/threads-core@0.1.32) (2020-07-16)
+
+**Note:** Version bump only for package @textile/threads-core

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@textile/threads-core",
-	"version": "0.1.31",
+	"version": "0.1.32",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/crypto/CHANGELOG.md
+++ b/packages/crypto/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [0.1.3](https://github.com/textileio/js-threads/compare/@textile/threads-crypto@0.1.2...@textile/threads-crypto@0.1.3) (2020-07-16)
+
+**Note:** Version bump only for package @textile/threads-crypto

--- a/packages/crypto/package-lock.json
+++ b/packages/crypto/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@textile/threads-crypto",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/database/CHANGELOG.md
+++ b/packages/database/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [0.6.4](https://github.com/textileio/js-threads/compare/@textile/threads-database@0.6.3...@textile/threads-database@0.6.4) (2020-07-16)
+
+**Note:** Version bump only for package @textile/threads-database

--- a/packages/database/package-lock.json
+++ b/packages/database/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@textile/threads-database",
-	"version": "0.6.3",
+	"version": "0.6.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/encoding/CHANGELOG.md
+++ b/packages/encoding/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [0.1.32](https://github.com/textileio/js-threads/compare/@textile/threads-encoding@0.1.31...@textile/threads-encoding@0.1.32) (2020-07-16)
+
+**Note:** Version bump only for package @textile/threads-encoding

--- a/packages/encoding/package-lock.json
+++ b/packages/encoding/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@textile/threads-encoding",
-	"version": "0.1.31",
+	"version": "0.1.32",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/id/CHANGELOG.md
+++ b/packages/id/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [0.1.12](https://github.com/textileio/js-threads/compare/@textile/threads-id@0.1.11...@textile/threads-id@0.1.12) (2020-07-16)
+
+**Note:** Version bump only for package @textile/threads-id

--- a/packages/id/package-lock.json
+++ b/packages/id/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@textile/threads-id",
-	"version": "0.1.11",
+	"version": "0.1.12",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/multiaddr/CHANGELOG.md
+++ b/packages/multiaddr/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [0.0.23](https://github.com/textileio/js-threads/compare/@textile/multiaddr@0.0.22...@textile/multiaddr@0.0.23) (2020-07-16)
+
+**Note:** Version bump only for package @textile/multiaddr

--- a/packages/multiaddr/package-lock.json
+++ b/packages/multiaddr/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@textile/multiaddr",
-	"version": "0.0.22",
+	"version": "0.0.23",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/network-client/CHANGELOG.md
+++ b/packages/network-client/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [0.6.3](https://github.com/textileio/js-threads/compare/@textile/threads-network-client@0.6.2...@textile/threads-network-client@0.6.3) (2020-07-16)
+
+**Note:** Version bump only for package @textile/threads-network-client

--- a/packages/network-client/package-lock.json
+++ b/packages/network-client/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@textile/threads-network-client",
-	"version": "0.6.2",
+	"version": "0.6.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/network/CHANGELOG.md
+++ b/packages/network/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [0.5.3](https://github.com/textileio/js-threads/compare/@textile/threads-network@0.5.2...@textile/threads-network@0.5.3) (2020-07-16)
+
+**Note:** Version bump only for package @textile/threads-network

--- a/packages/network/package-lock.json
+++ b/packages/network/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@textile/threads-network",
-	"version": "0.5.2",
+	"version": "0.5.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/security/CHANGELOG.md
+++ b/packages/security/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [0.2.3](https://github.com/textileio/js-threads/compare/@textile/security@0.2.2...@textile/security@0.2.3) (2020-07-16)
+
+**Note:** Version bump only for package @textile/security

--- a/packages/security/package-lock.json
+++ b/packages/security/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@textile/security",
-	"version": "0.2.2",
+	"version": "0.2.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/store/CHANGELOG.md
+++ b/packages/store/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [0.1.19](https://github.com/textileio/js-threads/compare/@textile/threads-store@0.1.18...@textile/threads-store@0.1.19) (2020-07-16)
+
+**Note:** Version bump only for package @textile/threads-store

--- a/packages/store/package-lock.json
+++ b/packages/store/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@textile/threads-store",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/threads/CHANGELOG.md
+++ b/packages/threads/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [0.3.4](https://github.com/textileio/js-threads/compare/@textile/threads@0.3.3...@textile/threads@0.3.4) (2020-07-16)
+
+**Note:** Version bump only for package @textile/threads

--- a/packages/threads/package-lock.json
+++ b/packages/threads/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@textile/threads",
-	"version": "0.3.3",
+	"version": "0.3.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
Signed-off-by: Carson Farmer <carson.farmer@gmail.com>

## Description

This is a preliminary setup to support automatic semantic versioning of our lerna sub-packages, for automated releases. It will allow us to simply create a release, and then kick off the automatic lerna publish process. It _should_ in theory release correct semantic versions because we are using conventional commits already. That part is mostly untested, so we'll have to see.

Fixes #176 
Fixes #232 

This allows us to use the https://www.conventionalcommits.org/en/v1.0.0/ conventions for changes. We're already pretty much doing this, just one interesting thing to note:

* `feat: allow provided config object to extend other configs` is basically a minor version bump
* `refactor!: drop support for Node 6` is basically a major version bump
* `fix: correct minor typos in code` is basically a patch version bump

There are plenty more details in the above link.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Honestly, in a pretty reckless and 🤠 type way. Let's just get it out and test it!

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

