### PR TITLE
Prefix child db by threadid when starting

### DIFF
--- a/packages/database/src/db.spec.ts
+++ b/packages/database/src/db.spec.ts
@@ -419,23 +419,6 @@ describe("Database", () => {
       await db.close()
     })
 
-    it("should throw if our database and thread id do not match", async function () {
-      const store = new MemoryDatastore()
-      let db = new Database(store)
-      const ident = await Database.randomIdentity()
-      await db.start(ident, { threadID: ThreadID.fromRandom() })
-      await db.close()
-      // Now 'reopen' the database
-      db = new Database(store)
-      try {
-        await db.start(ident, { threadID: ThreadID.fromRandom() })
-        throw new Error("should have throw")
-      } catch (err) {
-        expect(err).to.equal(mismatchError)
-      }
-      await db.close()
-    })
-
     it("start a functional db using withUserAuth", async () => {
       const store = new MemoryDatastore()
 


### PR DESCRIPTION
Signed-off-by: Carson Farmer <carson.farmer@gmail.com>

## Description

This PR changes the internals of how we "start" Databases. Now, the actual "opening" of the database is deferred until it is actually "started". Additionally, while we can "create" a database and its underlying components (dispatcher, event handler, etc) at construction time, none of this stuff is turned on until we actually start it. Additionally, all DB keys are prefixed by the threadid in a transparent way. So that, in theory, a user doesn't _really_ need to worry about threadid at all. Additionally, this makes the database "name" (which is really just sugar for the developer) default to "thread.db". For developer who want to "sandbox" their db from other user dbs, they can specify their own name.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

All existing tests should pass. Additionally, some previous behavior that was expected to fail, should no longer fail, so some checks for this were actually removed. With that in mind, some _additional_ tests should be applied here.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

> This PR template comes from https://github.com/embeddedartistry/templates
