### PR TITLE
feat: return thread id on remote join

### DIFF
--- a/packages/client/src/index.spec.ts
+++ b/packages/client/src/index.spec.ts
@@ -182,7 +182,7 @@ describe("Client", function () {
         addr.replace("/ip4/127.0.0.1", "/dns4/threads1/")
       })
       // We can 'exclude' the local addrs because we swapped them for "dns" entries
-      await client2.joinFromInfo(info, false, [
+      const id1 = await client2.joinFromInfo(info, false, [
         // Include the known collections to bootstrap with...
         {
           name: "Person",
@@ -193,12 +193,14 @@ describe("Client", function () {
           schema: schema2,
         },
       ])
+      expect(id1.equals(dbID)).to.equal(true)
       const info2 = await client2.getDBInfo(dbID)
       expect(info2.addrs.length).to.be.greaterThan(1)
       expect(info2.key).to.equal(info.key)
       // Now we should have it locally, so no need to add again
       try {
-        await client2.newDBFromAddr(info.addrs[0], dbKey, [])
+        const id2 = await client2.newDBFromAddr(info.addrs[0], dbKey, [])
+        expect(id2.equals(id1)).to.equal(true)
       } catch (err) {
         // Expect this db to already exist on this peer
         expect(err.toString()).to.include("already exists")


### PR DESCRIPTION
BREAKING CHANGE

## Description

Extracts Thread ID from remote join addr and returns this from joinFromInfo and newDBFromAddr methods.

Fixes #504 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Local tests are running and/or have been updated to reflect the new changes

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

> This PR template comes from https://github.com/embeddedartistry/templates
