### PR TITLE
fix: #522 ListCollections API not exposed on Client

### DIFF
--- a/packages/client/src/index.spec.ts
+++ b/packages/client/src/index.spec.ts
@@ -147,6 +147,11 @@ describe("Client", function () {
         expect(err.toString()).to.include("collection not found")
       }
     })
+
+    it("ListCollections should return a list of collections", async () => {
+        const list = await client.listCollections(dbID)
+        expect(list).to.have.length(1);
+    })
   })
 
   describe(".listDBs", () => {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -403,6 +403,17 @@ export class Client {
   }
 
   /**
+   * Lists the collections in a thread
+   * @param thread the ID of the database
+   */
+  public async listCollections(thread: ThreadID): Promise<Array<pb.GetCollectionInfoReply.AsObject>> {
+    const req = new pb.ListCollectionsRequest()
+    req.setDbid(thread.toBytes())
+    const resp = (await this.unary(API.ListCollections, req)) as pb.ListCollectionsReply.AsObject
+    return resp.collectionsList
+  }
+
+  /**
    * newCollection registers a new collection schema under the given name.
    * The schema must be a valid json-schema.org schema, and can be a JSON string or object.
    * @param threadID the ID of the database


### PR DESCRIPTION
## Description

Adds the ability for the client to list the collections of a thread

Fixes #522 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test Lists the collections in a thread and verifies that there is one item in the list.

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

> This PR template comes from https://github.com/embeddedartistry/templates
