### PR TITLE
fix: longer timeout on auth msgs

### DIFF
--- a/packages/security/src/index.ts
+++ b/packages/security/src/index.ts
@@ -89,10 +89,10 @@ export type APISig = {
  */
 export async function createAPISig(
   secret: string,
-  date: Date = new Date(Date.now() + 1000 * 60)
+  date: Date = new Date(Date.now() + 1000 * 60 * 30) // Default to 30 minutes
 ): Promise<APISig> {
   const sec = multibase.decode(secret)
-  const msg = (date ?? new Date()).toISOString()
+  const msg = date.toISOString()
   const hash = new HMAC(sec)
   const mac = hash.update(Buffer.from(msg)).digest()
   const sig = multibase.encode("base32", Buffer.from(mac)).toString()
@@ -128,7 +128,7 @@ export async function createAPISig(
 export async function createUserAuth(
   key: string,
   secret: string,
-  date: Date = new Date(Date.now() + 1000 * 60),
+  date?: Date,
   token?: string
 ): Promise<UserAuth> {
   const partial = await createAPISig(secret, date)


### PR DESCRIPTION
Signed-off-by: Carson Farmer <carson.farmer@gmail.com>

## Description

This extends the default auth timeline from 1 minute to 30 minutes

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

All existing tests should continue to pass

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

> This PR template comes from https://github.com/embeddedartistry/templates
