### PR TITLE
Adds support for write transaction abort

### DIFF
--- a/packages/client/src/index.spec.ts
+++ b/packages/client/src/index.spec.ts
@@ -308,19 +308,23 @@ describe("Client", function () {
   describe(".readTransaction", () => {
     let existingPersonID: string
     let transaction: ReadTransaction | undefined
+
     before(async () => {
       const instances = await client.create(dbID, "Person", [createPerson()])
       existingPersonID = instances.pop()!
       transaction = client.readTransaction(dbID, "Person")
     })
+
     it("should start a transaction", async () => {
       expect(transaction).to.not.be.undefined
       await transaction!.start()
     })
+
     it("should able to check for an existing instance", async () => {
       const has = await transaction!.has([existingPersonID])
       expect(has).to.be.true
     })
+
     it("should be able to find an existing instance", async () => {
       const find = await transaction!.findByID<Person>(existingPersonID)
       expect(find).to.not.be.undefined
@@ -333,8 +337,20 @@ describe("Client", function () {
       expect(instance).to.have.property("_id")
       expect(instance?._id).to.deep.equal(existingPersonID)
     })
+
     it("should be able to close/end an transaction", async () => {
       await transaction!.end()
+    })
+
+    it("should throw on invalid transaction information", async function () {
+      const t = client.readTransaction(dbID, "fake")
+      await t.start()
+      try {
+        await t.has(["anything"])
+        throw new Error("should have thrown")
+      } catch (err) {
+        expect(err.toString()).to.include("collection not found")
+      }
     })
   })
   describe(".writeTransaction", () => {

--- a/packages/client/src/index.spec.ts
+++ b/packages/client/src/index.spec.ts
@@ -344,11 +344,6 @@ describe("Client", function () {
 
     context("complete transaction", function () {
       before(async () => {
-        const register = await client.newCollection(
-          dbID,
-          "Person",
-          personSchema
-        )
         const instances = await client.create(dbID, "Person", [person])
         existingPersonID = instances.length ? instances[0] : ""
         person["_id"] = existingPersonID
@@ -394,7 +389,6 @@ describe("Client", function () {
 
     context("rejected transaction", function () {
       before(async () => {
-        await client.newCollection(dbID, "Person", personSchema)
         const instances = await client.create(dbID, "Person", [person])
         existingPersonID = instances.length ? instances[0] : ""
         person["_id"] = existingPersonID
@@ -402,7 +396,6 @@ describe("Client", function () {
       })
 
       it("should not commit an aborted write transaction", async function () {
-        this.timeout(20000)
         await transaction?.start()
         const newPerson = createPerson()
         const ids = (await transaction?.create<Person>([newPerson])) ?? []
@@ -416,6 +409,7 @@ describe("Client", function () {
       })
     })
   })
+
   describe(".listen", () => {
     const listener: { events: number; close?: () => void } = { events: 0 }
     const person = createPerson()

--- a/packages/client/src/index.spec.ts
+++ b/packages/client/src/index.spec.ts
@@ -149,8 +149,8 @@ describe("Client", function () {
     })
 
     it("ListCollections should return a list of collections", async () => {
-        const list = await client.listCollections(dbID)
-        expect(list).to.have.length(1);
+      const list = await client.listCollections(dbID)
+      expect(list).to.have.length(1)
     })
   })
 
@@ -341,47 +341,79 @@ describe("Client", function () {
     const person = createPerson()
     let existingPersonID: string
     let transaction: WriteTransaction | undefined
-    before(async () => {
-      const instances = await client.create(dbID, "Person", [person])
-      existingPersonID = instances.length ? instances[0] : ""
-      person["_id"] = existingPersonID
-      transaction = client.writeTransaction(dbID, "Person")
+
+    context("complete transaction", function () {
+      before(async () => {
+        const register = await client.newCollection(
+          dbID,
+          "Person",
+          personSchema
+        )
+        const instances = await client.create(dbID, "Person", [person])
+        existingPersonID = instances.length ? instances[0] : ""
+        person["_id"] = existingPersonID
+        transaction = client.writeTransaction(dbID, "Person")
+      })
+      it("should start a transaction", async () => {
+        expect(transaction).to.not.be.undefined
+        await transaction!.start()
+      })
+      it("should be able to create an instance", async () => {
+        const newPerson = createPerson()
+        const entities = await transaction!.create<Person>([newPerson])
+        expect(entities).to.not.be.undefined
+        expect(entities!.length).to.equal(1)
+      })
+      it("should able to check for an existing instance", async () => {
+        const has = await transaction!.has([existingPersonID])
+        expect(has).to.be.true
+      })
+      it("should be able to find an existing instance", async () => {
+        const find = await transaction!.findByID<Person>(existingPersonID)
+        expect(find).to.not.be.undefined
+        expect(find).to.haveOwnProperty("instance")
+        const instance = find!.instance
+        expect(instance).to.not.be.undefined
+        expect(instance).to.have.property("firstName", "Adam")
+        expect(instance).to.have.property("lastName", "Doe")
+        expect(instance).to.have.property("age", 21)
+        expect(instance).to.have.property("_id")
+        expect(instance?._id).to.deep.equal(existingPersonID)
+      })
+      it("should be able to save an existing instance", async () => {
+        person.age = 99
+        const saved = await transaction!.save([person])
+        expect(saved).to.be.undefined
+        const deleted = await transaction!.delete([person._id])
+        expect(deleted).to.be.undefined
+      })
+      it("should be able to close/end an transaction", async () => {
+        await transaction!.end()
+      })
     })
-    it("should start a transaction", async () => {
-      expect(transaction).to.not.be.undefined
-      await transaction!.start()
-    })
-    it("should be able to create an instance", async () => {
-      const newPerson = createPerson()
-      const entities = await transaction!.create<Person>([newPerson])
-      expect(entities).to.not.be.undefined
-      expect(entities!.length).to.equal(1)
-    })
-    it("should able to check for an existing instance", async () => {
-      const has = await transaction!.has([existingPersonID])
-      expect(has).to.be.true
-    })
-    it("should be able to find an existing instance", async () => {
-      const find = await transaction!.findByID<Person>(existingPersonID)
-      expect(find).to.not.be.undefined
-      expect(find).to.haveOwnProperty("instance")
-      const instance = find!.instance
-      expect(instance).to.not.be.undefined
-      expect(instance).to.have.property("firstName", "Adam")
-      expect(instance).to.have.property("lastName", "Doe")
-      expect(instance).to.have.property("age", 21)
-      expect(instance).to.have.property("_id")
-      expect(instance?._id).to.deep.equal(existingPersonID)
-    })
-    it("should be able to save an existing instance", async () => {
-      person.age = 99
-      const saved = await transaction!.save([person])
-      expect(saved).to.be.undefined
-      const deleted = await transaction!.delete([person._id])
-      expect(deleted).to.be.undefined
-    })
-    it("should be able to close/end an transaction", async () => {
-      await transaction!.end()
+
+    context("rejected transaction", function () {
+      before(async () => {
+        await client.newCollection(dbID, "Person", personSchema)
+        const instances = await client.create(dbID, "Person", [person])
+        existingPersonID = instances.length ? instances[0] : ""
+        person["_id"] = existingPersonID
+        transaction = client.writeTransaction(dbID, "Person")
+      })
+
+      it("should not commit an aborted write transaction", async function () {
+        this.timeout(20000)
+        await transaction?.start()
+        const newPerson = createPerson()
+        const ids = (await transaction?.create<Person>([newPerson])) ?? []
+        expect(ids).to.not.be.undefined
+        // Abort transaction
+        const rejected = await transaction?.abort()
+        expect(rejected).to.be.undefined
+        // After aborted transaction, it should still be false
+        const exHas = await client.has(dbID, "Person", ids)
+        expect(exHas).to.equal(false)
+      })
     })
   })
   describe(".listen", () => {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -406,10 +406,15 @@ export class Client {
    * Lists the collections in a thread
    * @param thread the ID of the database
    */
-  public async listCollections(thread: ThreadID): Promise<Array<pb.GetCollectionInfoReply.AsObject>> {
+  public async listCollections(
+    thread: ThreadID
+  ): Promise<Array<pb.GetCollectionInfoReply.AsObject>> {
     const req = new pb.ListCollectionsRequest()
     req.setDbid(thread.toBytes())
-    const resp = (await this.unary(API.ListCollections, req)) as pb.ListCollectionsReply.AsObject
+    const resp = (await this.unary(
+      API.ListCollections,
+      req
+    )) as pb.ListCollectionsReply.AsObject
     return resp.collectionsList
   }
 

--- a/packages/client/src/models/ReadTransaction.ts
+++ b/packages/client/src/models/ReadTransaction.ts
@@ -18,6 +18,7 @@ import { Transaction } from "./Transaction"
 
 /**
  * ReadTransaction performs a read-only bulk transaction on the underlying store.
+ * {@inheritDoc @textile/threads-client#Transaction}
  */
 export class ReadTransaction extends Transaction<
   ReadTransactionRequest,

--- a/packages/client/src/models/ReadTransaction.ts
+++ b/packages/client/src/models/ReadTransaction.ts
@@ -19,6 +19,55 @@ import { Transaction } from "./Transaction"
 /**
  * ReadTransaction performs a read-only bulk transaction on the underlying store.
  * {@inheritDoc @textile/threads-client#Transaction}
+ * @example
+ * Create a new entry in our collection
+ * ```typescript
+ * import {Client, ThreadID} from '@textile/threads'
+ *
+ * interface Astronaut {
+ *   name: string
+ *   missions: number
+ *   _id: string
+ * }
+ *
+ * async function createBuzz (client: Client, threadID: ThreadID) {
+ *   const buzz: Astronaut = {
+ *     name: 'Buzz',
+ *     missions: 2,
+ *     _id: '',
+ *   }
+ *
+ *   const t = client.writeTransaction(threadID, 'astronauts')
+ *   await t.start()
+ *   await t.create([buzz])
+ *   await t.end() // Commit
+ * }
+ * ```
+ *
+ * @example
+ * Abort an in-flight transaction
+ * ```typescript
+ * import {Client, ThreadID} from '@textile/threads'
+ *
+ * interface Astronaut {
+ *   name: string
+ *   missions: number
+ *   _id: string
+ * }
+ *
+ * async function createBuzz (client: Client, threadID: ThreadID) {
+ *   const buzz: Astronaut = {
+ *     name: 'Buzz',
+ *     missions: 2,
+ *     _id: '',
+ *   }
+ *
+ *   const t = client.writeTransaction(threadID, 'astronauts')
+ *   await t.start()
+ *   await t.create([buzz])
+ *   await t.abort() // Abort
+ * }
+ * ```
  */
 export class ReadTransaction extends Transaction<
   ReadTransactionRequest,

--- a/packages/client/src/models/Transaction.ts
+++ b/packages/client/src/models/Transaction.ts
@@ -34,7 +34,7 @@ export class Transaction<
 
   /**
    * setReject rejects the current transaction, rather than flushing the results to the remote store via end.
-   * @param reject The optional reason for rejecting the transaction.
+   * @param reject A function which accepts a reason for rejecting the transaction.
    */
   protected setReject(reject: (reason?: any) => void): void {
     this.client.onEnd((status: grpc.Code, message: string) => {

--- a/packages/client/src/models/WriteTransaction.ts
+++ b/packages/client/src/models/WriteTransaction.ts
@@ -21,6 +21,56 @@ import { Transaction } from "./Transaction"
 
 /**
  * WriteTransaction performs a mutating bulk transaction on the underlying store.
+ * {@inheritDoc @textile/threads-client#Transaction}
+ * @example
+ * Create a new entry in our collection
+ * ```typescript
+ * import {Client, ThreadID} from '@textile/threads'
+ *
+ * interface Astronaut {
+ *   name: string
+ *   missions: number
+ *   _id: string
+ * }
+ *
+ * async function createBuzz (client: Client, threadID: ThreadID) {
+ *   const buzz: Astronaut = {
+ *     name: 'Buzz',
+ *     missions: 2,
+ *     _id: '',
+ *   }
+ *
+ *   const t = client.writeTransaction(threadID, 'astronauts')
+ *   await t.start()
+ *   await t.create([buzz])
+ *   await t.end() // Commit
+ * }
+ * ```
+ *
+ * @example
+ * Abort an in-flight transaction
+ * ```typescript
+ * import {Client, ThreadID} from '@textile/threads'
+ *
+ * interface Astronaut {
+ *   name: string
+ *   missions: number
+ *   _id: string
+ * }
+ *
+ * async function createBuzz (client: Client, threadID: ThreadID) {
+ *   const buzz: Astronaut = {
+ *     name: 'Buzz',
+ *     missions: 2,
+ *     _id: '',
+ *   }
+ *
+ *   const t = client.writeTransaction(threadID, 'astronauts')
+ *   await t.start()
+ *   await t.create([buzz])
+ *   await t.abort() // Abort
+ * }
+ * ```
  */
 export class WriteTransaction extends Transaction<
   WriteTransactionRequest,
@@ -200,6 +250,30 @@ export class WriteTransaction extends Transaction<
 
   /**
    * abort quits the current transaction and drops all associated updates.
+   * @example
+   * Abort an in-flight transaction
+   * ```typescript
+   * import {Client, ThreadID} from '@textile/threads'
+   *
+   * interface Astronaut {
+   *   name: string
+   *   missions: number
+   *   _id: string
+   * }
+   *
+   * async function example (client: Client, threadID: ThreadID) {
+   *   const buzz: Astronaut = {
+   *     name: 'Buzz',
+   *     missions: 2,
+   *     _id: '',
+   *   }
+   *
+   *   const t = client.writeTransaction(threadID, 'astronauts')
+   *   await t.start()
+   *   await t.create([buzz])
+   *   await t.abort() // Abort
+   * }
+   * ```
    */
   public async abort(): Promise<void> {
     return new Promise<void>((resolve, reject) => {

--- a/packages/client/src/models/WriteTransaction.ts
+++ b/packages/client/src/models/WriteTransaction.ts
@@ -197,4 +197,19 @@ export class WriteTransaction extends Transaction<
       this.client.send(req)
     })
   }
+
+  /**
+   * abort quits the current transaction and drops all associated updates.
+   */
+  public async abort(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      // Invalid request with no type set
+      const req = new WriteTransactionRequest()
+      this.client.send(req)
+      super.setReject(({ message }) => {
+        if (message === "no WriteTransactionRequest type set") resolve()
+        else reject(message)
+      })
+    })
+  }
 }


### PR DESCRIPTION
Signed-off-by: Carson Farmer <carson.farmer@gmail.com>

## Description

This adds support for aborting an "inflight" transaction, rather than calling end (which by default commits the transaction). This is needed, because keeping a transaction "open" (not ending it) will actually block and can be a serious issue if multiple clients are interacting with a remote daemon at the same time. Additionally, in cases where updates need to be rolled back, previously there was no way to manage this without just letting the transaction time out.

Fixes #529 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

New tests were added, old tests were reconfigured to address the new API(s). Additionally, a test to check for a transaction "blocking" will be added.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

> This PR template comes from https://github.com/embeddedartistry/templates
