### PR TITLE
Better behavior on transaction end.

### DIFF
--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -19,7 +19,10 @@ import { ThreadID } from "@textile/threads-id"
 import toJsonSchema, { JSONSchema3or4 } from "to-json-schema"
 import {
   CriterionJSON,
+  Event,
   Filter,
+  Patch,
+  PatchType,
   Query,
   QueryJSON,
   ReadTransaction,
@@ -40,6 +43,9 @@ export {
   CriterionJSON,
   SortJSON,
   JSONSchema3or4,
+  Event,
+  Patch,
+  PatchType,
 }
 
 function isEmpty(obj: any) {
@@ -74,7 +80,9 @@ function getFunctionBody(fn: ((...args: any[]) => any) | string): string {
  *   - event: An object describing the update event (see core.Event).
  *   - instance: The current instance as a JavaScript object before the update event is applied.
  *
- * A falsy return value indicates a failed validation.
+ * A falsy return value indicates a failed validation. Note that the function arguments must
+ * be named as documented here (writer, event, instance). These functions run in a secure sandbox
+ * where these argument names are specified.
  *
  * Having access to writer, event, and instance opens the door to a variety of app-specific logic.
  * Textile Buckets file-level access roles are implemented in part with a write validator.
@@ -83,8 +91,9 @@ function getFunctionBody(fn: ((...args: any[]) => any) | string): string {
  *   - reader: The multibase-encoded public key identity of the reader.
  *   - instance: The current instance as a JavaScript object.
  *
- * The function must return a JavaScript object. Most implementation will modify and return the
- * current instance.
+ * The function must return a JavaScript object. Most implementations will modify and return the
+ * current instance. Note that the function arguments must be named as documented here (reader,
+ * instance). These functions run in a secure sandbox where these argument names are specified.
  * Like write validation, read filtering opens the door to a variety of app-specific logic.
  * Textile Buckets file-level access roles are implemented in part with a read filter.
  */
@@ -93,7 +102,7 @@ export interface CollectionConfig<W = any, R = W> {
   schema?: JSONSchema3or4 | any // Union type to indicate that JSONSchema is preferred but any works
   indexes?: pb.Index.AsObject[]
   writeValidator?:
-    | ((writer: string, event: any, instance: W) => boolean)
+    | ((writer: string, event: Event, instance: W) => boolean)
     | string
   readFilter?: ((reader: string, instance: R) => R) | string
 }

--- a/packages/client/src/models/Transaction.ts
+++ b/packages/client/src/models/Transaction.ts
@@ -29,7 +29,16 @@ export class Transaction<
    * end completes (flushes) the transaction. All operations between start and end will be applied as a single transaction upon a call to end.
    */
   public async end(): Promise<void> {
-    this.client.close()
+    return new Promise<void>((resolve, reject) => {
+      this.client.onEnd((status: grpc.Code, message: string) => {
+        if (status !== grpc.Code.OK) {
+          reject(new Error(message))
+        } else {
+          resolve()
+        }
+      })
+      this.client.finishSend()
+    })
   }
 
   /**

--- a/packages/client/src/models/index.ts
+++ b/packages/client/src/models/index.ts
@@ -5,3 +5,54 @@
 export * from "./query"
 export * from "./ReadTransaction"
 export * from "./WriteTransaction"
+
+/**
+ * Event represents an update event.
+ * It contains information about when the update occured, the instance id, the collection name,
+ * and the update patch itself.
+ */
+export interface Event {
+  /**
+   * Unix timestamp.
+   */
+  timestamp: number
+  /**
+   * The instance identifier (_id).
+   */
+  _id: string
+  /**
+   * The collection to which the updated instance belongs.
+   */
+  collection_name: string
+  /**
+   * The underlying patch update information. See {@link Patch} for details.
+   */
+  patch: Patch
+}
+
+/**
+ * PatchType represents the type of instance update. One of delete, create, or save.
+ */
+export type PatchType = "delete" | "create" | "save"
+
+/**
+ * Patch represents an update to an instance.
+ * It contains information about the update type, the instance that was updated, and the update operation.
+ */
+export interface Patch {
+  /**
+   * The type of operation. One of delete, create, or save.
+   */
+  type: PatchType
+  /**
+   * The instance identifier (_id).
+   */
+  instance_id: string
+  /**
+   * The actual JSON patch document or undefined for a delete operation.
+   * The patch can either be the state of an instance in the case of a create operation,
+   * or a json patch document/array as defined in https://tools.ietf.org/html/rfc6902.
+   * See {@link https://github.com/evanphx/json-patch} for implementation details.
+   */
+  json_patch?: any
+}

--- a/packages/client/src/models/index.ts
+++ b/packages/client/src/models/index.ts
@@ -8,7 +8,7 @@ export * from "./WriteTransaction"
 
 /**
  * Event represents an update event.
- * It contains information about when the update occured, the instance id, the collection name,
+ * It contains information about when the update occurred, the instance id, the collection name,
  * and the update patch itself.
  */
 export interface Event {


### PR DESCRIPTION
## Description

BREAKING CHANGE

Ending a transaction will now throw if the transaction wasn't successful, and simply returns void if it was. It is still an async function, and the API itself hasn't changed. This PR also includes better docs for writeValidator and readFilter function types, and adjusts some tests to reflect the new (better) transaction behavior.

Fixes #571
Fixes #560
Fixes #559


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Existing tests should continue to pass, with some minor modifications where errors were not previously throw (but should have been).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

> This PR template comes from https://github.com/embeddedartistry/templates
