### PR TITLE
Moves timeout error into context

### DIFF
--- a/packages/context/src/index.spec.ts
+++ b/packages/context/src/index.spec.ts
@@ -1,6 +1,5 @@
-import { expirationError } from "@textile/security"
 import { expect } from "chai"
-import { Context, ContextInterface } from "./index"
+import { Context, ContextInterface, errors } from "./index"
 
 describe("Context", () => {
   let validJson = {}
@@ -16,7 +15,7 @@ describe("Context", () => {
       context.toJSON()
       throw new Error("should have thrown")
     } catch (err) {
-      expect(err).to.equal(expirationError)
+      expect(err).to.equal(errors.expirationError)
     }
     validMsg = new Date(Date.now() + 1000 * 60).toUTCString()
     context.withAPISig({
@@ -48,7 +47,7 @@ describe("Context", () => {
       context.toJSON()
       throw new Error("should have thrown")
     } catch (err) {
-      expect(err).to.equal(expirationError)
+      expect(err).to.equal(errors.expirationError)
     }
     // Should renew
     const metadata = await context.toMetadata()
@@ -90,7 +89,7 @@ describe("Context", () => {
       context.toJSON()
       throw new Error("should have thrown")
     } catch (err) {
-      expect(err).to.equal(expirationError)
+      expect(err).to.equal(errors.expirationError)
     }
   })
 })

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -1,10 +1,15 @@
 import { grpc } from "@improbable-eng/grpc-web"
-import {
-  createAPISig,
-  expirationError,
-  KeyInfo,
-  UserAuth,
-} from "@textile/security"
+import { createAPISig, KeyInfo, UserAuth } from "@textile/security"
+
+export const errors = {
+  /**
+   * expirationError is an error your app will receive anytime your credentials have expired.
+   * @public
+   */
+  expirationError: new Error(
+    "Auth expired. Consider calling withKeyInfo or withAPISig to refresh."
+  ),
+}
 
 /**
  * The set of host strings used by any gPRC clients.
@@ -283,7 +288,7 @@ export class Context implements ContextInterface {
     const { ...json } = this._context
     // If we're expired, throw...
     if (this.isExpired) {
-      throw expirationError
+      throw errors.expirationError
     }
     return json
   }


### PR DESCRIPTION
Context is actually the only place from which this error is ever thrown, so it should be in Context. Additionally, this PR "namespaces" error here, which fixes an issue with ES modules in the browser.

Note that this is actually a BREAKING CHANGE for our downstream tests (no APIs are affected). So we should make sure this is the right move.